### PR TITLE
fix for segfault when null hunks are passed to callbacks

### DIFF
--- a/include/cppgit2/diff.hpp
+++ b/include/cppgit2/diff.hpp
@@ -611,7 +611,7 @@ public:
   // the delta.
   class hunk : public libgit2_api {
   public:
-    hunk(const git_diff_hunk *c_ptr) : c_struct_(*c_ptr) {}
+    hunk(const git_diff_hunk *c_ptr) : c_struct_(c_ptr ? *c_ptr : git_diff_hunk{0}) {}
 
     // Starting line number in old_file
     int old_start() const { return c_struct_.old_start; }


### PR DESCRIPTION
I'm not certain what the "right" solution for this is, but as-is there is a segfault when diffs are printed.

A null hunk pointer is passed from https://github.com/libgit2/libgit2/blob/main/src/libgit2/diff_print.c#L164 via https://github.com/bold84/cppgit2/blob/master/src/diff.cpp#L199 to the hunk constructor, causing dereference of null.

This quick patch changes the hunk constructor to initialise to zeros if passed a null value.

This breaks parallelism with line and delta, which do not have such a check, but it prevents the segfault.