### PR TITLE
provide error class and return code in git_exception

### DIFF
--- a/include/cppgit2/apply.hpp
+++ b/include/cppgit2/apply.hpp
@@ -28,8 +28,8 @@ public:
   public:
     // Default construct apply::options
     options() {
-      if (git_apply_options_init(&default_options_, GIT_APPLY_OPTIONS_VERSION))
-        throw git_exception();
+      git_exception::throw_nonzero(
+          git_apply_options_init(&default_options_, GIT_APPLY_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
     }
 

--- a/include/cppgit2/blame.hpp
+++ b/include/cppgit2/blame.hpp
@@ -36,11 +36,9 @@ public:
   class options : public libgit2_api {
   public:
     options() : c_ptr_(nullptr) {
-      auto ret =
-          git_blame_init_options(&default_options_, GIT_BLAME_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+        git_blame_init_options(&default_options_, GIT_BLAME_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_blame_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/checkout.hpp
+++ b/include/cppgit2/checkout.hpp
@@ -117,11 +117,10 @@ public:
   class options : public libgit2_api {
   public:
     options() {
-      auto ret = git_checkout_init_options(&default_options_,
-                                           GIT_CHECKOUT_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+          git_checkout_init_options(&default_options_,
+                                    GIT_CHECKOUT_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_checkout_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/cherrypick.hpp
+++ b/include/cppgit2/cherrypick.hpp
@@ -11,11 +11,10 @@ public:
   class options : public libgit2_api {
   public:
     options() : c_ptr_(nullptr) {
-      auto ret = git_cherrypick_init_options(&default_options_,
-                                             GIT_CHERRYPICK_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+        git_cherrypick_init_options(&default_options_,
+                                    GIT_CHERRYPICK_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_cherrypick_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/clone.hpp
+++ b/include/cppgit2/clone.hpp
@@ -13,11 +13,9 @@ public:
   class options : public libgit2_api {
   public:
     options() : c_ptr_(nullptr) {
-      auto ret =
-          git_clone_init_options(&default_options_, GIT_CLONE_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+          git_clone_init_options(&default_options_, GIT_CLONE_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_clone_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/diff.hpp
+++ b/include/cppgit2/diff.hpp
@@ -135,11 +135,9 @@ public:
   class options : public libgit2_api {
   public:
     options() {
-      auto ret =
-          git_diff_init_options(&default_options_, GIT_DIFF_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+          git_diff_init_options(&default_options_, GIT_DIFF_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_diff_options *c_ptr) : c_ptr_(c_ptr) {}
@@ -402,10 +400,10 @@ public:
     // Print diff statistics to a git_buf.
     data_buffer to_buffer(format format, size_t width) {
       data_buffer result;
-      if (git_diff_stats_to_buf(result.c_ptr(), c_ptr_,
+      git_exception::throw_nonzero(
+          git_diff_stats_to_buf(result.c_ptr(), c_ptr_,
                                 static_cast<git_diff_stats_format_t>(format),
-                                width))
-        throw git_exception();
+                                width));
       return result;
     }
 
@@ -429,11 +427,10 @@ public:
   class format_email_options : public libgit2_api {
   public:
     format_email_options() : c_ptr_(nullptr) {
-      auto ret = git_diff_format_email_init_options(
-          &default_options_, GIT_DIFF_FORMAT_EMAIL_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+          git_diff_format_email_init_options(
+              &default_options_, GIT_DIFF_FORMAT_EMAIL_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     format_email_options(git_diff_format_email_options *c_ptr)
@@ -777,11 +774,10 @@ public:
   class find_options : public libgit2_api {
   public:
     find_options() : c_ptr_(nullptr) {
-      auto ret = git_diff_find_init_options(&default_options_,
-                                            GIT_DIFF_FIND_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+          git_diff_find_init_options(&default_options_,
+                                     GIT_DIFF_FIND_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     find_options(git_diff_find_options *c_ptr) : c_ptr_(c_ptr) {}
@@ -860,11 +856,10 @@ public:
   class patchid_options : public libgit2_api {
   public:
     patchid_options() : c_ptr_(nullptr) {
-      auto ret = git_diff_patchid_init_options(
-          &default_options_, GIT_DIFF_PATCHID_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+          git_diff_patchid_init_options(
+              &default_options_, GIT_DIFF_PATCHID_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     patchid_options(git_diff_patchid_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/fetch.hpp
+++ b/include/cppgit2/fetch.hpp
@@ -13,11 +13,9 @@ public:
   class options : public libgit2_api {
   public:
     options() : c_ptr_(nullptr) {
-      auto ret =
-          git_fetch_init_options(&default_options_, GIT_FETCH_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+        git_fetch_init_options(&default_options_, GIT_FETCH_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_fetch_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/git_exception.hpp
+++ b/include/cppgit2/git_exception.hpp
@@ -7,19 +7,130 @@ namespace cppgit2 {
 
 class git_exception : public std::exception {
 public:
-  git_exception() {
+  enum class error_class;
+  enum class error_code;
+
+  git_exception(int return_code = static_cast<int>(error_code::error)) {
     auto error = git_error_last();
+    code_ = return_code <= 0 ? static_cast<error_code>(return_code) : error_code::error;
     message_ = error ? error->message : "unknown error";
+    klass_ = error ? static_cast<error_class>(error->klass) : error_class::none;
   }
-  git_exception(const char *message) : message_(message) {}
-  git_exception(const std::string &message) : message_(message.c_str()) {}
+  git_exception(const char *message,
+                error_class klass = error_class::none,
+                error_code code = error_code::error)
+  : message_(message),
+    code_(code),
+    klass_(klass)
+  {}
+  git_exception(const std::string &message,
+                error_class klass = error_class::none,
+                error_code code = error_code::error)
+  : message_(message),
+    code_(code),
+    klass_(klass)
+  {}
   virtual ~git_exception() throw() {}
-  virtual const char *what() const throw() { return message_; }
+  virtual const char *what() const throw() { return message_.c_str(); }
+  error_code code() const { return code_; }
+  error_class klass() const { return klass_; }
 
   static void clear() { git_error_clear(); }
 
+  static int throw_nonzero(int return_code) {
+    if (return_code == 0) {
+      return return_code;
+    } else {
+      throw git_exception(return_code);
+    }
+  }
+  static bool throw_nonbool(int return_code) {
+    if (return_code == 1)
+      return true;
+    else if (return_code == 0)
+      return false;
+    else
+      throw git_exception(return_code);
+  }
+
+  enum class error_code : int {
+    ok             =   0, // No error
+    error          =  -1, // Generic error
+    notfound       =  -3, // Requested object could not be found
+    exists         =  -4, // Object exists preventing operation
+    ambiguous      =  -5, // More than one object matches
+    bufs           =  -6, // Output buffer too short to hold data
+    user           =  -7, // User callback custom failure
+    barerepo       =  -8, // Operation not allowed on bare repository
+    unbornbranch   =  -9, // HEAD refers to branch with no commits
+    unmerged       = -10, // Merge in progress prevented operation
+    nonfastforward = -11, // Reference was not fast-forwardable
+    invalidspec    = -12, // Name/ref spec was not in a valid format
+    conflict       = -13, // Checkout conflicts prevented operation
+    locked         = -14, // Lock file prevented operation
+    modified       = -15, // Reference value does not match expected
+    auth           = -16, // Authentication error
+    certificate    = -17, // Server certificate is invalid
+    applied        = -18, // Patch/merge has already been applied
+    peel           = -19, // The requested peel operation is not possible
+    eof            = -20, // Unexpected EOF
+    invalid        = -21, // Invalid operation or input
+    uncommitted    = -22, // Uncommitted changes in index prevented operation
+    directory      = -23, // The operation is not valid for a directory
+    mergeconflict  = -24, // A merge conflict exists and cannot continue
+  
+    passthrough    = -30, // A user-configured callback refused to act
+    iterover       = -31, // Signals end of iteration with iterator
+    retry          = -32, // Internal only
+    mismatch       = -33, // Hashsum mismatch in object
+    indexdirty     = -34, // Unsaved changes in the index would be overwritten
+    applyfail      = -35, // Patch application failed
+    owner          = -36, // The object is not owned by the current user
+  };
+
+  enum class error_class : int {
+    none           = GIT_ERROR_NONE,
+    nomemory       = GIT_ERROR_NOMEMORY,
+    os             = GIT_ERROR_OS,
+    invalid        = GIT_ERROR_INVALID,
+    reference      = GIT_ERROR_REFERENCE,
+    zlib           = GIT_ERROR_ZLIB,
+    repository     = GIT_ERROR_REPOSITORY,
+    config         = GIT_ERROR_CONFIG,
+    regex          = GIT_ERROR_REGEX,
+    odb            = GIT_ERROR_ODB,
+    index          = GIT_ERROR_INDEX,
+    object         = GIT_ERROR_OBJECT,
+    net            = GIT_ERROR_NET,
+    tag            = GIT_ERROR_TAG,
+    tree           = GIT_ERROR_TREE,
+    indexer        = GIT_ERROR_INDEXER,
+    ssl            = GIT_ERROR_SSL,
+    submodule      = GIT_ERROR_SUBMODULE,
+    thread         = GIT_ERROR_THREAD,
+    stash          = GIT_ERROR_STASH,
+    checkout       = GIT_ERROR_CHECKOUT,
+    fetchhead      = GIT_ERROR_FETCHHEAD,
+    merge          = GIT_ERROR_MERGE,
+    ssh            = GIT_ERROR_SSH,
+    filter         = GIT_ERROR_FILTER,
+    revert         = GIT_ERROR_REVERT,
+    callback       = GIT_ERROR_CALLBACK,
+    cherrypick     = GIT_ERROR_CHERRYPICK,
+    describe       = GIT_ERROR_DESCRIBE,
+    rebase         = GIT_ERROR_REBASE,
+    filesystem     = GIT_ERROR_FILESYSTEM,
+    patch          = GIT_ERROR_PATCH,
+    worktree       = GIT_ERROR_WORKTREE,
+    //sha            = GIT_ERROR_SHA,
+    http           = GIT_ERROR_HTTP,
+    internal       = GIT_ERROR_INTERNAL,
+  };
+
 protected:
-  const char *message_;
+  std::string message_;
+  error_code code_;
+  error_class klass_;
 };
 
 } // namespace cppgit2

--- a/include/cppgit2/indexer.hpp
+++ b/include/cppgit2/indexer.hpp
@@ -82,11 +82,10 @@ public:
   class options : public libgit2_api {
   public:
     options() {
-      auto ret = git_indexer_init_options(&default_options_,
-                                          GIT_INDEXER_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+          git_indexer_init_options(&default_options_,
+                                   GIT_INDEXER_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_indexer_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/libgit2_api.hpp
+++ b/include/cppgit2/libgit2_api.hpp
@@ -14,8 +14,8 @@ public:
 
   std::tuple<int, int, int> version() const {
     int major, minor, revision;
-    if (git_libgit2_version(&major, &minor, &revision))
-      throw git_exception();
+    git_exception::throw_nonzero(
+        git_libgit2_version(&major, &minor, &revision));
     return std::tuple<int, int, int>{major, minor, revision};
   }
 };

--- a/include/cppgit2/merge.hpp
+++ b/include/cppgit2/merge.hpp
@@ -76,8 +76,8 @@ public:
       // Initializes a git_merge_file_input with default values. Equivalent to
       // creating an instance with GIT_MERGE_FILE_INPUT_INIT.
       input() {
-        if (git_merge_file_input_init(&c_struct_, GIT_MERGE_FILE_INPUT_VERSION))
-          throw git_exception();
+        git_exception::throw_nonzero(
+            git_merge_file_input_init(&c_struct_, GIT_MERGE_FILE_INPUT_VERSION));
       }
 
       // Construct from libgit2 C ptr
@@ -155,11 +155,10 @@ public:
     class options : public libgit2_api {
     public:
       options() : c_ptr_(nullptr) {
-        auto ret = git_merge_file_init_options(&default_options_,
-                                               GIT_MERGE_FILE_OPTIONS_VERSION);
+        git_exception::throw_nonzero(
+            git_merge_file_init_options(&default_options_,
+                                        GIT_MERGE_FILE_OPTIONS_VERSION));
         c_ptr_ = &default_options_;
-        if (ret != 0)
-          throw git_exception();
       }
 
       options(git_merge_file_options *c_ptr) : c_ptr_(c_ptr) {}
@@ -235,11 +234,9 @@ public:
   class options : public libgit2_api {
   public:
     options() : c_ptr_(nullptr) {
-      auto ret =
-          git_merge_init_options(&default_options_, GIT_MERGE_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+          git_merge_init_options(&default_options_, GIT_MERGE_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_merge_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/odb.hpp
+++ b/include/cppgit2/odb.hpp
@@ -168,8 +168,8 @@ public:
     // Create a copy of an odb_object
     object copy() const {
       object result(nullptr);
-      if (git_odb_object_dup(&result.c_ptr_, c_ptr_))
-        throw git_exception();
+      git_exception::throw_nonzero(
+          git_odb_object_dup(&result.c_ptr_, c_ptr_));
       return result;
     }
 
@@ -288,24 +288,24 @@ public:
     // the size declared with git_odb_open_wstream()
     oid finalize_write() {
       oid result;
-      if (git_odb_stream_finalize_write(result.c_ptr(), c_ptr_))
-        throw git_exception();
+      git_exception::throw_nonzero(
+          git_odb_stream_finalize_write(result.c_ptr(), c_ptr_));
       return result;
     }
 
     // Read from an odb stream
     // Most backends don't implement streaming reads
     void read(char *buffer, size_t length) {
-      if (git_odb_stream_read(c_ptr_, buffer, length))
-        throw git_exception();
+      git_exception::throw_nonzero(
+          git_odb_stream_read(c_ptr_, buffer, length));
     }
 
     // Write to an odb stream
     // This method will fail if the total number of received bytes exceeds the
     // size declared with git_odb_open_wstream()
     void write(const char *buffer, size_t length) {
-      if (git_odb_stream_write(c_ptr_, buffer, length))
-        throw git_exception();
+      git_exception::throw_nonzero(
+          git_odb_stream_write(c_ptr_, buffer, length));
     }
 
   private:

--- a/include/cppgit2/oid.hpp
+++ b/include/cppgit2/oid.hpp
@@ -95,7 +95,7 @@ public:
     int add(const std::string &text_id) {
       auto result = git_oid_shorten_add(c_ptr_, text_id.c_str());
       if (result < 0)
-        throw git_exception();
+        throw git_exception(result);
       return result;
     }
 

--- a/include/cppgit2/proxy.hpp
+++ b/include/cppgit2/proxy.hpp
@@ -16,11 +16,9 @@ public:
   class options : public libgit2_api {
   public:
     options() {
-      auto ret =
-          git_proxy_init_options(&default_options_, GIT_PROXY_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+        git_proxy_init_options(&default_options_, GIT_PROXY_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_proxy_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/push.hpp
+++ b/include/cppgit2/push.hpp
@@ -11,11 +11,9 @@ public:
   class options : public libgit2_api {
   public:
     options() {
-      auto ret =
-          git_push_init_options(&default_options_, GIT_PUSH_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+          git_push_init_options(&default_options_, GIT_PUSH_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_push_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/rebase.hpp
+++ b/include/cppgit2/rebase.hpp
@@ -134,11 +134,10 @@ public:
   class options : public libgit2_api {
   public:
     options() {
-      auto ret = git_rebase_init_options(&default_options_,
-                                         GIT_REBASE_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+        git_rebase_init_options(&default_options_,
+                                GIT_REBASE_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_rebase_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/refdb.hpp
+++ b/include/cppgit2/refdb.hpp
@@ -27,8 +27,8 @@ public:
   // This mechanism is implementation specific. For on-disk reference
   // databases, for example, this may pack all loose references.
   void compress() {
-    if (git_refdb_compress(c_ptr_))
-      throw git_exception();
+    git_exception::throw_nonzero(
+      git_refdb_compress(c_ptr_));
   }
 
 private:

--- a/include/cppgit2/remote.hpp
+++ b/include/cppgit2/remote.hpp
@@ -41,11 +41,10 @@ public:
   class callbacks : public libgit2_api {
   public:
     callbacks() : c_ptr_(nullptr) {
-      auto ret = git_remote_init_callbacks(&default_options_,
-                                           GIT_REMOTE_CALLBACKS_VERSION);
+      git_exception::throw_nonzero(
+        git_remote_init_callbacks(&default_options_,
+                                  GIT_REMOTE_CALLBACKS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     callbacks(git_remote_callbacks *c_ptr) : c_ptr_(c_ptr) {}
@@ -78,11 +77,10 @@ public:
   class create_options : public libgit2_api {
   public:
     create_options() : c_ptr_(nullptr) {
-      auto ret = git_remote_create_init_options(
-          &default_options_, GIT_REMOTE_CREATE_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+        git_remote_create_init_options(
+            &default_options_, GIT_REMOTE_CREATE_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     create_options(git_remote_create_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/repository.hpp
+++ b/include/cppgit2/repository.hpp
@@ -83,11 +83,10 @@ public:
   class init_options : public libgit2_api {
   public:
     init_options() : c_ptr_(nullptr) {
-      auto ret = git_repository_init_options_init(
-          &default_options_, GIT_REPOSITORY_INIT_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+        git_repository_init_options_init(
+            &default_options_, GIT_REPOSITORY_INIT_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     init_options(git_repository_init_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/revert.hpp
+++ b/include/cppgit2/revert.hpp
@@ -13,11 +13,10 @@ public:
   class options : public libgit2_api {
   public:
     options() {
-      auto ret = git_revert_init_options(&default_options_,
-                                         GIT_REVERT_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+        git_revert_init_options(&default_options_,
+                                GIT_REVERT_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_revert_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/stash.hpp
+++ b/include/cppgit2/stash.hpp
@@ -38,11 +38,10 @@ public:
     class options : public libgit2_api {
     public:
       options() {
-        auto ret = git_stash_apply_init_options(
-            &default_options_, GIT_STASH_APPLY_OPTIONS_VERSION);
+        git_exception::throw_nonzero(
+          git_stash_apply_init_options(
+              &default_options_, GIT_STASH_APPLY_OPTIONS_VERSION));
         c_ptr_ = &default_options_;
-        if (ret != 0)
-          throw git_exception();
       }
 
       options(git_stash_apply_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/status.hpp
+++ b/include/cppgit2/status.hpp
@@ -43,11 +43,10 @@ public:
   class options : public libgit2_api {
   public:
     options() {
-      auto ret = git_status_init_options(&default_options_,
-                                         GIT_STATUS_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+        git_status_init_options(&default_options_,
+                                GIT_STATUS_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     options(git_status_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/submodule.hpp
+++ b/include/cppgit2/submodule.hpp
@@ -144,11 +144,10 @@ public:
   class update_options : public libgit2_api {
   public:
     update_options() : c_ptr_(nullptr) {
-      auto ret = git_submodule_update_init_options(
-          &default_options_, GIT_SUBMODULE_UPDATE_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+          git_submodule_update_init_options(
+              &default_options_, GIT_SUBMODULE_UPDATE_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     update_options(git_submodule_update_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/include/cppgit2/tree.hpp
+++ b/include/cppgit2/tree.hpp
@@ -41,9 +41,8 @@ public:
         : c_ptr_(e.c_ptr_), owner_(e.owner_) {
 
       if (c_ptr_ && owner_ == ownership::user) {
-        if (git_tree_entry_dup(&c_ptr_, e.c_ptr_)){
-          throw git_exception();
-        }
+        git_exception::throw_nonzero(
+          git_tree_entry_dup(&c_ptr_, e.c_ptr_));
       }
     }
     // copy-assignment operator
@@ -52,9 +51,8 @@ public:
         return *this;
       }
       owner_ = ownership::user;
-      if (git_tree_entry_dup(&c_ptr_, other.c_ptr_)){
-        throw git_exception();
-      }
+      git_exception::throw_nonzero(
+        git_tree_entry_dup(&c_ptr_, other.c_ptr_));
       return *this;
     }
     // move constructor
@@ -94,8 +92,8 @@ public:
     // Duplicate a tree entry
     entry copy() const {
       entry result;
-      if (git_tree_entry_dup(&result.c_ptr_, c_ptr_))
-        throw git_exception();
+      git_exception::throw_nonzero(
+        git_tree_entry_dup(&result.c_ptr_, c_ptr_));
       return result;
     }
 

--- a/include/cppgit2/worktree.hpp
+++ b/include/cppgit2/worktree.hpp
@@ -87,11 +87,10 @@ public:
   class add_options : public libgit2_api {
   public:
     add_options() : c_ptr_(nullptr) {
-      auto ret = git_worktree_add_init_options(
-          &default_options_, GIT_WORKTREE_ADD_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+        git_worktree_add_init_options(
+            &default_options_, GIT_WORKTREE_ADD_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     add_options(git_worktree_add_options *c_ptr) : c_ptr_(c_ptr) {}
@@ -134,11 +133,10 @@ public:
   // Worktree prune options structure
   class prune_options : public libgit2_api {
     prune_options() : c_ptr_(nullptr) {
-      auto ret = git_worktree_prune_init_options(
-          &default_options_, GIT_WORKTREE_PRUNE_OPTIONS_VERSION);
+      git_exception::throw_nonzero(
+        git_worktree_prune_init_options(
+            &default_options_, GIT_WORKTREE_PRUNE_OPTIONS_VERSION));
       c_ptr_ = &default_options_;
-      if (ret != 0)
-        throw git_exception();
     }
 
     prune_options(git_worktree_prune_options *c_ptr) : c_ptr_(c_ptr) {}

--- a/src/blame.cpp
+++ b/src/blame.cpp
@@ -28,10 +28,10 @@ blame& blame::operator=(blame&& other) {
 blame blame::get_blame_for_buffer(const blame &reference,
                                   const std::string &buffer) {
   blame result(nullptr, ownership::user);
-  if (git_blame_buffer(&result.c_ptr_,
-                       const_cast<git_blame *>(reference.c_ptr()),
-                       buffer.c_str(), buffer.size()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_blame_buffer(&result.c_ptr_,
+                     const_cast<git_blame *>(reference.c_ptr()),
+                     buffer.c_str(), buffer.size()));
   return result;
 }
 

--- a/src/blob.cpp
+++ b/src/blob.cpp
@@ -5,8 +5,8 @@ namespace cppgit2 {
 blob::blob() : c_ptr_(nullptr) {}
 
 blob::blob(const git_blob *c_ptr) {
-  if (git_blob_dup(&c_ptr_, const_cast<git_blob *>(c_ptr)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_blob_dup(&c_ptr_, const_cast<git_blob *>(c_ptr)));
 }
 
 blob::~blob() {
@@ -33,8 +33,8 @@ blob blob::copy() const {
 }
 
 blob::blob(blob const& other) {
-  if (git_blob_dup(&c_ptr_, other.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_blob_dup(&c_ptr_, other.c_ptr_));
 }
 blob& blob::operator=(const blob &other) {
   if (this == &other)
@@ -43,8 +43,8 @@ blob& blob::operator=(const blob &other) {
   if (c_ptr_){
     git_blob_free(c_ptr_);
   }
-  if (git_blob_dup(&c_ptr_, const_cast<git_blob *>(other.c_ptr_)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_blob_dup(&c_ptr_, const_cast<git_blob *>(other.c_ptr_)));
   return *this;
 }
 

--- a/src/commit.cpp
+++ b/src/commit.cpp
@@ -29,10 +29,10 @@ void commit::amend(const oid &id, const std::string &update_ref,
                    const signature &author, const signature &committer,
                    const std::string &message_encoding,
                    const std::string &message, const cppgit2::tree &tree) {
-  if (git_commit_amend(const_cast<git_oid *>(id.c_ptr()), c_ptr_,
-                       update_ref.c_str(), author.c_ptr(), committer.c_ptr(),
-                       message_encoding.c_str(), message.c_str(), tree.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+   git_commit_amend(const_cast<git_oid *>(id.c_ptr()), c_ptr_,
+                    update_ref.c_str(), author.c_ptr(), committer.c_ptr(),
+                    message_encoding.c_str(), message.c_str(), tree.c_ptr()));
 }
 
 signature commit::author() const {
@@ -58,14 +58,14 @@ commit commit::copy() const {
 }
 
 commit::commit(commit const& other) : owner_(ownership::user){
-  if (git_commit_dup(&c_ptr_, other.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_commit_dup(&c_ptr_, other.c_ptr_));
 }
 
 std::string commit::operator[](const std::string &field) const {
   data_buffer result(nullptr);
-  if (git_commit_header_field(result.c_ptr(), c_ptr_, field.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_commit_header_field(result.c_ptr(), c_ptr_, field.c_str()));
   return result.to_string();
 }
 
@@ -97,15 +97,15 @@ std::string commit::message_raw() const {
 
 commit commit::ancestor(unsigned long n) const {
   commit result(nullptr, ownership::user);
-  if (git_commit_nth_gen_ancestor(&result.c_ptr_, c_ptr_, n))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_commit_nth_gen_ancestor(&result.c_ptr_, c_ptr_, n));
   return result;
 }
 
 commit commit::parent(const unsigned int n) const {
   commit result(nullptr, ownership::user);
-  if (git_commit_parent(&result.c_ptr_, c_ptr_, n))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_commit_parent(&result.c_ptr_, c_ptr_, n));
   return result;
 }
 
@@ -141,8 +141,8 @@ offset_minutes commit::time_offset() const {
 
 tree commit::tree() const {
   cppgit2::tree result(nullptr, ownership::user);
-  if (git_commit_tree(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_commit_tree(&result.c_ptr_, c_ptr_));
   return result;
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -27,98 +27,98 @@ config& config::operator=(config&& other) {
 }
 
 void config::delete_entry(const std::string &name) {
-  if (git_config_delete_entry(c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_delete_entry(c_ptr_, name.c_str()));
 }
 
 void config::delete_entry(const std::string &name, const std::string &regexp) {
-  if (git_config_delete_multivar(c_ptr_, name.c_str(), regexp.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_delete_multivar(c_ptr_, name.c_str(), regexp.c_str()));
 }
 
 std::string config::locate_global_config() {
   data_buffer result(nullptr);
-  if (git_config_find_global(result.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_find_global(result.c_ptr()));
   return result.to_string();
 }
 
 std::string config::locate_global_config_in_programdata() {
   data_buffer result(nullptr);
-  if (git_config_find_programdata(result.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_find_programdata(result.c_ptr()));
   return result.to_string();
 }
 
 std::string config::locate_global_system_config() {
   data_buffer result(nullptr);
-  if (git_config_find_system(result.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_find_system(result.c_ptr()));
   return result.to_string();
 }
 
 std::string config::locate_global_xdg_compatible_config() {
   data_buffer result(nullptr);
-  if (git_config_find_xdg(result.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_find_xdg(result.c_ptr()));
   return result.to_string();
 }
 
 config config::new_config() {
   config result(nullptr, ownership::user);
-  if (git_config_new(&result.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_new(&result.c_ptr_));
   return result;
 }
 
 config config::open_default_config() {
   config result(nullptr, ownership::user);
-  if (git_config_open_default(&result.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_open_default(&result.c_ptr_));
   return result;
 }
 
 config config::open_global_config(config &conf) {
   config result(nullptr, ownership::user);
-  if (git_config_open_global(&result.c_ptr_, conf.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_open_global(&result.c_ptr_, conf.c_ptr_));
   return result;
 }
 
 config config::open_config_at_level(const config &parent,
                                     priority_level level) {
   config result(nullptr, ownership::user);
-  if (git_config_open_level(&result.c_ptr_, parent.c_ptr(),
-                            static_cast<git_config_level_t>(level)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_open_level(&result.c_ptr_, parent.c_ptr(),
+                          static_cast<git_config_level_t>(level)));
   return result;
 }
 
 config::entry config::operator[](const std::string &name) {
   config::entry result(nullptr, ownership::user);
-  if (git_config_get_entry(&result.c_ptr_, c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_get_entry(&result.c_ptr_, c_ptr_, name.c_str()));
   return result;
 }
 
 bool config::value_as_bool(const std::string &name) {
   int result;
-  if (git_config_get_bool(&result, c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_get_bool(&result, c_ptr_, name.c_str()));
   return result;
 }
 
 int32_t config::value_as_int32(const std::string &name) {
   int32_t result;
-  if (git_config_get_int32(&result, c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_get_int32(&result, c_ptr_, name.c_str()));
   return result;
 }
 
 int64_t config::value_as_int64(const std::string &name) {
   int64_t result;
-  if (git_config_get_int64(&result, c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_get_int64(&result, c_ptr_, name.c_str()));
   return result;
 }
 
@@ -136,85 +136,85 @@ std::string config::value_as_string(const std::string &name) {
 
 data_buffer config::value_as_data_buffer(const std::string &name) {
   data_buffer result(nullptr);
-  if (git_config_get_string_buf(result.c_ptr(), c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_get_string_buf(result.c_ptr(), c_ptr_, name.c_str()));
   return result;
 }
 
 std::string config::path(const std::string &name) {
   data_buffer result(nullptr);
-  if (git_config_get_path(result.c_ptr(), c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_get_path(result.c_ptr(), c_ptr_, name.c_str()));
   return result.to_string();
 }
 
 void config::insert_entry(const std::string &name, bool value) {
-  if (git_config_set_bool(c_ptr_, name.c_str(), value))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_set_bool(c_ptr_, name.c_str(), value));
 }
 
 void config::insert_entry(const std::string &name, int32_t value) {
-  if (git_config_set_int32(c_ptr_, name.c_str(), value))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_set_int32(c_ptr_, name.c_str(), value));
 }
 
 void config::insert_entry(const std::string &name, int64_t value) {
-  if (git_config_set_int64(c_ptr_, name.c_str(), value))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_set_int64(c_ptr_, name.c_str(), value));
 }
 
 void config::insert_entry(const std::string &name, const std::string &value) {
-  if (git_config_set_string(c_ptr_, name.c_str(), value.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_set_string(c_ptr_, name.c_str(), value.c_str()));
 }
 
 void config::insert_multiple(const std::string &name, const std::string &regexp,
                              const std::string &new_value) {
-  if (git_config_set_multivar(c_ptr_, name.c_str(), regexp.c_str(),
-                              new_value.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_set_multivar(c_ptr_, name.c_str(), regexp.c_str(),
+                            new_value.c_str()));
 }
 
 transaction config::lock() {
   transaction result;
   git_transaction *result_ptr = result.c_ptr();
-  if (git_config_lock(&result_ptr, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_lock(&result_ptr, c_ptr_));
   return result;
 }
 
 bool config::parse_as_bool(const std::string &value) {
   int result;
-  if (git_config_parse_bool(&result, value.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_parse_bool(&result, value.c_str()));
   return result;
 }
 
 int32_t config::parse_as_int32(const std::string &value) {
   int32_t result;
-  if (git_config_parse_int32(&result, value.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_parse_int32(&result, value.c_str()));
   return result;
 }
 
 int64_t config::parse_as_int64(const std::string &value) {
   int64_t result;
-  if (git_config_parse_int64(&result, value.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_parse_int64(&result, value.c_str()));
   return result;
 }
 
 std::string config::parse_path(const std::string &value) {
   data_buffer result(nullptr);
-  if (git_config_parse_path(result.c_ptr(), value.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_parse_path(result.c_ptr(), value.c_str()));
   return result.to_string();
 }
 
 config config::snapshot() {
   config result(nullptr, ownership::user);
-  if (git_config_snapshot(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_snapshot(&result.c_ptr_, c_ptr_));
   return result;
 }
 
@@ -244,8 +244,8 @@ void config::for_each(std::function<void(const entry &)> visitor) {
     return 0;
   };
 
-  if (git_config_foreach(c_ptr_, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_foreach(c_ptr_, callback_c, (void *)(&wrapper)));
 }
 
 void config::for_each(const std::string &regexp,
@@ -263,9 +263,9 @@ void config::for_each(const std::string &regexp,
     return 0;
   };
 
-  if (git_config_foreach_match(c_ptr_, regexp.c_str(), callback_c,
-                               (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_config_foreach_match(c_ptr_, regexp.c_str(), callback_c,
+                             (void *)(&wrapper)));
 }
 
 const git_config *config::c_ptr() const { return c_ptr_; }

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -2,46 +2,46 @@
 using namespace cppgit2;
 
 credential::credential() {
-  if (git_credential_default_new(&c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_credential_default_new(&c_ptr_));
 }
 
 credential::credential(const std::string &username,
                        const std::string &password) {
-  if (git_credential_userpass_plaintext_new(&c_ptr_, username.c_str(),
-                                            password.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_credential_userpass_plaintext_new(&c_ptr_, username.c_str(),
+                                          password.c_str()));
 }
 
 credential::credential(const std::string &username,
                        const std::string &public_key,
                        const std::string &private_key,
                        const std::string &passphrase) {
-  if (git_credential_ssh_key_new(&c_ptr_, username.c_str(), public_key.c_str(),
-                                 private_key.c_str(), passphrase.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_credential_ssh_key_new(&c_ptr_, username.c_str(), public_key.c_str(),
+                               private_key.c_str(), passphrase.c_str()));
 }
 
 credential::credential(const std::string &username) {
-  if (git_credential_ssh_key_from_agent(&c_ptr_, username.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_credential_ssh_key_from_agent(&c_ptr_, username.c_str()));
 }
 
 credential::credential(const std::string &username,
                        git_credential_ssh_interactive_cb prompt_callback,
                        void *payload) {
-  if (git_credential_ssh_interactive_new(&c_ptr_, username.c_str(),
-                                         prompt_callback, payload))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_credential_ssh_interactive_new(&c_ptr_, username.c_str(),
+                                       prompt_callback, payload));
 }
 
 credential::credential(const std::string &username,
                        const std::string &public_key,
                        git_credential_sign_cb sign_callback, void *payload) {
-  if (git_credential_ssh_custom_new(&c_ptr_, username.c_str(),
-                                    public_key.c_str(), public_key.size(),
-                                    sign_callback, payload))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_credential_ssh_custom_new(&c_ptr_, username.c_str(),
+                                  public_key.c_str(), public_key.size(),
+                                  sign_callback, payload));
 }
 
 credential::~credential() {

--- a/src/diff.cpp
+++ b/src/diff.cpp
@@ -8,8 +8,8 @@ diff::diff() : c_ptr_(nullptr), owner_(ownership::libgit2) {}
 diff::diff(git_diff *c_ptr, ownership owner) : c_ptr_(c_ptr), owner_(owner) {}
 
 diff::diff(const std::string &buffer) {
-  if (git_diff_from_buffer(&c_ptr_, buffer.c_str(), buffer.size()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_from_buffer(&c_ptr_, buffer.c_str(), buffer.size()));
 }
 
 diff::~diff() {
@@ -55,12 +55,11 @@ diff::delta diff::compare_files(const std::pair<blob, std::string> &old_file,
   const char *new_as_path_c =
       new_file.second.empty() ? nullptr : new_file.second.c_str();
 
-  auto ret = git_diff_blobs(old_file.first.c_ptr(), old_as_path_c,
-                            new_file.first.c_ptr(), new_as_path_c,
-                            options.c_ptr_, file_callback, nullptr, nullptr,
-                            nullptr, (void *)(&result));
-  if (ret)
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_blobs(old_file.first.c_ptr(), old_as_path_c,
+                     new_file.first.c_ptr(), new_as_path_c,
+                     options.c_ptr_, file_callback, nullptr, nullptr,
+                     nullptr, (void *)(&result)));
   return result;
 }
 
@@ -73,8 +72,8 @@ bool diff::is_sorted_case_sensitive() const {
 }
 
 void diff::merge(const diff &from) {
-  if (git_diff_merge(c_ptr_, from.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_merge(c_ptr_, from.c_ptr()));
 }
 
 size_t diff::size() const { return git_diff_num_deltas(c_ptr_); }
@@ -89,9 +88,9 @@ char diff::status_char(delta::type status) const {
 
 std::string diff::to_string(diff::format format_type) const {
   git_buf result_buf = GIT_BUF_INIT;
-  if (git_diff_to_buf(&result_buf, c_ptr_,
-                      static_cast<git_diff_format_t>(format_type)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_to_buf(&result_buf, c_ptr_,
+                      static_cast<git_diff_format_t>(format_type)));
   auto result = data_buffer(&result_buf);
   return result.to_string();
 }
@@ -100,15 +99,15 @@ const git_diff *diff::c_ptr() const { return c_ptr_; }
 
 diff::stats diff::diff_stats() const {
   diff::stats result(nullptr);
-  if (git_diff_get_stats(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_get_stats(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 data_buffer diff::format_email(const format_email_options &options) {
   git_buf result_buf = GIT_BUF_INIT;
-  if (git_diff_format_email(&result_buf, c_ptr_, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_format_email(&result_buf, c_ptr_, options.c_ptr()));
   auto result = data_buffer(&result_buf);
   return result;
 }
@@ -171,9 +170,9 @@ void diff::for_each(
     return 0;
   };
 
-  if (git_diff_foreach(c_ptr_, file_callback_c, binary_callback_c,
-                       hunk_callback_c, line_callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_foreach(c_ptr_, file_callback_c, binary_callback_c,
+                       hunk_callback_c, line_callback_c, (void *)(&wrapper)));
 }
 
 void diff::print(diff::format format,
@@ -200,9 +199,9 @@ void diff::print(diff::format format,
     return 0;
   };
 
-  if (git_diff_print(c_ptr_, static_cast<git_diff_format_t>(format),
-                     line_callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_print(c_ptr_, static_cast<git_diff_format_t>(format),
+                     line_callback_c, (void *)(&wrapper)));
 }
 
 void diff::diff_blob_to_buffer(
@@ -266,12 +265,12 @@ void diff::diff_blob_to_buffer(
     return 0;
   };
 
-  if (git_diff_blob_to_buffer(old_blob.c_ptr(), old_as_path.c_str(), new_buffer,
+  git_exception::throw_nonzero(
+      git_diff_blob_to_buffer(old_blob.c_ptr(), old_as_path.c_str(), new_buffer,
                               new_buffer_length, new_as_path.c_str(),
                               options.c_ptr(), file_callback_c,
                               binary_callback_c, hunk_callback_c,
-                              line_callback_c, (void *)(&wrapper)))
-    throw git_exception();
+                              line_callback_c, (void *)(&wrapper)));
 }
 
 void diff::diff_between_buffers(
@@ -336,22 +335,22 @@ void diff::diff_between_buffers(
     return 0;
   };
 
-  if (git_diff_buffers(old_buffer, old_buffer_length, old_as_path.c_str(),
+  git_exception::throw_nonzero(
+      git_diff_buffers(old_buffer, old_buffer_length, old_as_path.c_str(),
                        new_buffer, new_buffer_length, new_as_path.c_str(),
                        options.c_ptr(), file_callback_c, binary_callback_c,
-                       hunk_callback_c, line_callback_c, (void *)(&wrapper)))
-    throw git_exception();
+                       hunk_callback_c, line_callback_c, (void *)(&wrapper)));
 }
 
 void diff::find_similar(const find_options &options) {
-  if (git_diff_find_similar(c_ptr_, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_find_similar(c_ptr_, options.c_ptr()));
 }
 
 oid diff::patchid(const patchid_options &options) {
   oid result;
-  if (git_diff_patchid(result.c_ptr(), c_ptr_, options.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_patchid(result.c_ptr(), c_ptr_, options.c_ptr_));
   return result;
 }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -29,8 +29,8 @@ index& index::operator=(index&& other) {
 }
 
 void index::add_entry(const entry &source_entry) {
-  if (git_index_add(c_ptr_, source_entry.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_add(c_ptr_, source_entry.c_ptr()));
 }
 
 void index::add_entries_that_match(
@@ -51,21 +51,21 @@ void index::add_entries_that_match(
   };
 
   auto pathspec_c = strarray(pathspec).c_ptr();
-  if (git_index_add_all(c_ptr_, pathspec_c, static_cast<int>(flags), callback_c,
-                        (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_add_all(c_ptr_, pathspec_c, static_cast<int>(flags), callback_c,
+                      (void *)(&wrapper)));
 }
 
 void index::add_entry_by_path(const std::string &path) {
-  if (git_index_add_bypath(c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_add_bypath(c_ptr_, path.c_str()));
 }
 
 void index::add_entry_from_buffer(const entry &entry,
                                   const std::string &buffer) {
-  if (git_index_add_frombuffer(c_ptr_, entry.c_ptr(), buffer.c_str(),
-                               buffer.size()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_add_frombuffer(c_ptr_, entry.c_ptr(), buffer.c_str(),
+                             buffer.size()));
 }
 
 index::capability index::capability_flags() const {
@@ -75,41 +75,41 @@ index::capability index::capability_flags() const {
 const oid index::checksum() { return oid(git_index_checksum(c_ptr_)); }
 
 void index::clear() {
-  if (git_index_clear(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_clear(c_ptr_));
 }
 
 void index::add_conflict_entry(const entry &ancestor_entry,
                                const entry &our_entry,
                                const entry &their_entry) {
-  if (git_index_conflict_add(c_ptr_, ancestor_entry.c_ptr(), our_entry.c_ptr(),
-                             their_entry.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_conflict_add(c_ptr_, ancestor_entry.c_ptr(), our_entry.c_ptr(),
+                           their_entry.c_ptr()));
 }
 
 void index::remove_all_conflicts() {
-  if (git_index_conflict_cleanup(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_conflict_cleanup(c_ptr_));
 }
 
 void index::remove_conflict_entries(const std::string &path) {
-  if (git_index_conflict_remove(c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_conflict_remove(c_ptr_, path.c_str()));
 }
 
 size_t index::size() const { return git_index_entrycount(c_ptr_); }
 
 size_t index::find_first(const std::string &path) {
   size_t result{0};
-  if (git_index_find(&result, c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_find(&result, c_ptr_, path.c_str()));
   return result;
 }
 
 size_t index::find_first_matching_prefix(const std::string &prefix) {
   size_t result{0};
-  if (git_index_find_prefix(&result, c_ptr_, prefix.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_find_prefix(&result, c_ptr_, prefix.c_str()));
   return result;
 }
 
@@ -174,18 +174,18 @@ std::string index::path() const {
 }
 
 void index::read(bool force) {
-  if (git_index_read(c_ptr_, force))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_read(c_ptr_, force));
 }
 
 void index::read_tree(const tree &tree) {
-  if (git_index_read_tree(c_ptr_, tree.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_read_tree(c_ptr_, tree.c_ptr()));
 }
 
 void index::remove_entry(const std::string &path, index::stage stage) {
-  if (git_index_remove(c_ptr_, path.c_str(), static_cast<int>(stage)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_remove(c_ptr_, path.c_str(), static_cast<int>(stage)));
 }
 
 void index::remove_entries_that_match(
@@ -205,28 +205,28 @@ void index::remove_entries_that_match(
   };
 
   auto pathspec_c = strarray(pathspec).c_ptr();
-  if (git_index_remove_all(c_ptr_, pathspec_c, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_remove_all(c_ptr_, pathspec_c, callback_c, (void *)(&wrapper)));
 }
 
 void index::remove_entry_by_path(const std::string &path) {
-  if (git_index_remove_bypath(c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_remove_bypath(c_ptr_, path.c_str()));
 }
 
 void index::remove_entries_in_directory(const std::string &dir, stage stage) {
-  if (git_index_remove_directory(c_ptr_, dir.c_str(), static_cast<int>(stage)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_remove_directory(c_ptr_, dir.c_str(), static_cast<int>(stage)));
 }
 
 void index::set_index_capabilities(capability caps) {
-  if (git_index_set_caps(c_ptr_, static_cast<int>(caps)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_set_caps(c_ptr_, static_cast<int>(caps)));
 }
 
 void index::set_version(unsigned int version) {
-  if (git_index_set_version(c_ptr_, version))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_set_version(c_ptr_, version));
 }
 
 void index::update_entries_that_match(
@@ -246,35 +246,35 @@ void index::update_entries_that_match(
   };
 
   auto pathspec_c = strarray(pathspec).c_ptr();
-  if (git_index_update_all(c_ptr_, pathspec_c, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_update_all(c_ptr_, pathspec_c, callback_c, (void *)(&wrapper)));
 }
 
 unsigned int index::version() const { return git_index_version(c_ptr_); }
 
 void index::write() {
-  if (git_index_write(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_write(c_ptr_));
 }
 
 oid index::write_tree() {
   oid result;
-  if (git_index_write_tree(result.c_ptr(), c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_write_tree(result.c_ptr(), c_ptr_));
   return result;
 }
 
 oid index::write_tree_to(const repository &repo) {
   oid result;
-  if (git_index_write_tree_to(result.c_ptr(), c_ptr_, repo.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_write_tree_to(result.c_ptr(), c_ptr_, repo.c_ptr_));
   return result;
 }
 
 index index::open(const std::string &path) {
   index result(nullptr, ownership::user);
-  if (git_index_open(&result.c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_index_open(&result.c_ptr_, path.c_str()));
   return result;
 }
 

--- a/src/indexer.cpp
+++ b/src/indexer.cpp
@@ -8,8 +8,8 @@ indexer::indexer(git_indexer *c_ptr, ownership owner)
 
 indexer::indexer(const std::string &path, unsigned int mode, const odb &odb,
                  const indexer::options &options) {
-  if (git_indexer_new(&c_ptr_, path.c_str(), mode, odb.c_ptr_, options.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_indexer_new(&c_ptr_, path.c_str(), mode, odb.c_ptr_, options.c_ptr_));
 }
 
 indexer::~indexer() {
@@ -31,15 +31,15 @@ indexer& indexer::operator=(indexer&& other) {
 }
 
 void indexer::append(void *data, size_t size) {
-  if (git_indexer_append(c_ptr_, data, size,
-                         const_cast<git_indexer_progress *>(progress_.c_ptr_)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_indexer_append(c_ptr_, data, size,
+                       const_cast<git_indexer_progress *>(progress_.c_ptr_)));
 }
 
 void indexer::commit() {
-  if (git_indexer_commit(c_ptr_,
-                         const_cast<git_indexer_progress *>(progress_.c_ptr_)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_indexer_commit(c_ptr_,
+                       const_cast<git_indexer_progress *>(progress_.c_ptr_)));
 }
 
 oid indexer::hash() { return oid(git_indexer_hash(c_ptr_)); }

--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -6,8 +6,8 @@ merge::file::result merge::merge_files(const merge::file::input &ancestor,
                                        const merge::file::input &theirs,
                                        const merge::file::options &options) {
   git_merge_file_result result;
-  if (git_merge_file(&result, ancestor.c_ptr(), ours.c_ptr(), theirs.c_ptr(),
-                     options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_merge_file(&result, ancestor.c_ptr(), ours.c_ptr(), theirs.c_ptr(),
+                     options.c_ptr()));
   return merge::file::result(&result);
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -33,8 +33,8 @@ oid object::id() const { return oid(git_object_id(c_ptr_)->id); }
 
 std::string object::short_id() const {
   git_buf result;
-  if (git_object_short_id(&result, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_object_short_id(&result, c_ptr_));
   return data_buffer(&result).to_string();
 }
 
@@ -43,8 +43,8 @@ object object::copy() const {
 }
 
 object::object(object const& other) : owner_(ownership::user){
-  if (git_object_dup(&c_ptr_, other.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_object_dup(&c_ptr_, other.c_ptr_));
 }
 
 std::string object::object_type_to_string(object_type type) {
@@ -54,9 +54,9 @@ std::string object::object_type_to_string(object_type type) {
 
 object object::peel_until(object_type target_type) {
   object result(nullptr, ownership::user);
-  if (git_object_peel(&result.c_ptr_, c_ptr_,
-                      static_cast<git_object_t>(target_type)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_object_peel(&result.c_ptr_, c_ptr_,
+                    static_cast<git_object_t>(target_type)));
   return result;
 }
 
@@ -88,28 +88,36 @@ blob object::as_blob() {
   if (type() == object::object_type::blob)
     return blob((git_blob *)c_ptr_);
   else
-    throw git_exception("object is not a blob");
+    throw git_exception("object is not a blob",
+                        git_exception::error_class::invalid,
+                        git_exception::error_code::invalid);
 }
 
 commit object::as_commit() {
   if (type() == object::object_type::commit)
     return commit((git_commit *)c_ptr_);
   else
-    throw git_exception("object is not a commit");
+    throw git_exception("object is not a commit",
+                        git_exception::error_class::invalid,
+                        git_exception::error_code::invalid);
 }
 
 tree object::as_tree() {
   if (type() == object::object_type::tree)
     return tree((git_tree *)c_ptr_);
   else
-    throw git_exception("object is not a tree");
+    throw git_exception("object is not a tree",
+                        git_exception::error_class::invalid,
+                        git_exception::error_code::invalid);
 }
 
 tag object::as_tag() {
   if (type() == object::object_type::tag)
     return tag((git_tag *)c_ptr_);
   else
-    throw git_exception("object is not a tag");
+    throw git_exception("object is not a tag",
+                        git_exception::error_class::invalid,
+                        git_exception::error_code::invalid);
 }
 
 } // namespace cppgit2

--- a/src/odb.cpp
+++ b/src/odb.cpp
@@ -27,18 +27,18 @@ odb& odb::operator=(odb&& other) {
 }
 
 void odb::add_alternate_backend(const backend &backend, int priority) {
-  if (git_odb_add_alternate(c_ptr_, backend.c_ptr_, priority))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_add_alternate(c_ptr_, backend.c_ptr_, priority));
 }
 
 void odb::add_backend(const backend &backend, int priority) {
-  if (git_odb_add_backend(c_ptr_, backend.c_ptr_, priority))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_add_backend(c_ptr_, backend.c_ptr_, priority));
 }
 
 void odb::add_disk_alternate_backend(const std::string &path) {
-  if (git_odb_add_disk_alternate(c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_add_disk_alternate(c_ptr_, path.c_str()));
 }
 
 odb::backend
@@ -46,25 +46,25 @@ odb::create_backend_for_loose_objects(const std::string &objects_dir,
                                       int compression_level, bool do_fsync,
                                       unsigned int dir_mode, file_mode mode) {
   odb::backend result;
-  if (git_odb_backend_loose(&result.c_ptr_, objects_dir.c_str(),
-                            compression_level, do_fsync, dir_mode,
-                            static_cast<unsigned int>(mode)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_backend_loose(&result.c_ptr_, objects_dir.c_str(),
+                          compression_level, do_fsync, dir_mode,
+                          static_cast<unsigned int>(mode)));
   return result;
 }
 
 odb::backend
 odb::create_backend_for_one_packfile(const std::string &index_file) {
   odb::backend result;
-  if (git_odb_backend_one_pack(&result.c_ptr_, index_file.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_backend_one_pack(&result.c_ptr_, index_file.c_str()));
   return result;
 }
 
 odb::backend odb::create_backend_for_packfiles(const std::string &objects_dir) {
   odb::backend result;
-  if (git_odb_backend_pack(&result.c_ptr_, objects_dir.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_backend_pack(&result.c_ptr_, objects_dir.c_str()));
   return result;
 }
 
@@ -73,8 +73,8 @@ void odb::expand_ids(const std::vector<expand_id> &ids) {
   for (auto &id : ids)
     ids_c.push_back(id.c_struct_);
 
-  if (git_odb_expand_ids(c_ptr_, ids_c.data(), ids.size()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_expand_ids(c_ptr_, ids_c.data(), ids.size()));
 }
 
 bool odb::exists(const oid &id) const {
@@ -83,8 +83,8 @@ bool odb::exists(const oid &id) const {
 
 oid odb::exists(const oid &id, size_t length) const {
   oid result;
-  if (git_odb_exists_prefix(result.c_ptr(), c_ptr_, id.c_ptr(), length))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_exists_prefix(result.c_ptr(), c_ptr_, id.c_ptr(), length));
   return result;
 }
 
@@ -104,38 +104,38 @@ void odb::for_each(std::function<void(const oid &)> visitor) {
     return 0;
   };
 
-  if (git_odb_foreach(c_ptr_, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_foreach(c_ptr_, callback_c, (void *)(&wrapper)));
 }
 
 oid odb::hash(const void *data, size_t length,
               cppgit2::object::object_type type) {
   oid result;
-  if (git_odb_hash(result.c_ptr(), data, length,
-                   static_cast<git_object_t>(type)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_hash(result.c_ptr(), data, length,
+                 static_cast<git_object_t>(type)));
   return result;
 }
 
 oid odb::hash_file(const std::string &path, cppgit2::object::object_type type) {
   oid result;
-  if (git_odb_hashfile(result.c_ptr(), path.c_str(),
-                       static_cast<git_object_t>(type)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_hashfile(result.c_ptr(), path.c_str(),
+                     static_cast<git_object_t>(type)));
   return result;
 }
 
 odb::backend odb::operator[](size_t index) const {
   odb::backend result;
-  if (git_odb_get_backend(&result.c_ptr_, c_ptr_, index))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_get_backend(&result.c_ptr_, c_ptr_, index));
   return result;
 }
 
 odb::object odb::read(const oid &id) const {
   odb::object result(nullptr);
-  if (git_odb_read(&result.c_ptr_, c_ptr_, id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_read(&result.c_ptr_, c_ptr_, id.c_ptr()));
   return result;
 }
 
@@ -143,30 +143,30 @@ std::pair<size_t, cppgit2::object::object_type>
 odb::read_header(const oid &id) const {
   size_t length_out;
   git_object_t object_type_out;
-  if (git_odb_read_header(&length_out, &object_type_out, c_ptr_, id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_read_header(&length_out, &object_type_out, c_ptr_, id.c_ptr()));
   return std::pair<size_t, cppgit2::object::object_type>{
       length_out, static_cast<cppgit2::object::object_type>(object_type_out)};
 }
 
 odb::object odb::read_prefix(const oid &id, size_t length) const {
   odb::object result(nullptr);
-  if (git_odb_read_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), length))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_read_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), length));
   return result;
 }
 
 void odb::refresh() {
-  if (git_odb_refresh(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_refresh(c_ptr_));
 }
 
 size_t odb::size() const { return git_odb_num_backends(c_ptr_); }
 
 odb odb::open(const std::string &objects_dir) {
   odb result(nullptr, ownership::user);
-  if (git_odb_open(&result.c_ptr_, objects_dir.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_open(&result.c_ptr_, objects_dir.c_str()));
   return result;
 }
 
@@ -175,8 +175,8 @@ odb::open_rstream(const oid &id) {
   stream result(nullptr);
   size_t length;
   git_object_t type;
-  if (git_odb_open_rstream(&result.c_ptr_, &length, &type, c_ptr_, id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_open_rstream(&result.c_ptr_, &length, &type, c_ptr_, id.c_ptr()));
   return std::tuple<odb::stream, size_t, cppgit2::object::object_type>{
       result, length, static_cast<cppgit2::object::object_type>(type)};
 }
@@ -184,19 +184,19 @@ odb::open_rstream(const oid &id) {
 odb::stream odb::open_wstream(cppgit2::object::object_size size,
                               cppgit2::object::object_type type) {
   stream result(nullptr);
-  if (git_odb_open_wstream(&result.c_ptr_, c_ptr_,
-                           static_cast<git_object_size_t>(size),
-                           static_cast<git_object_t>(type)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_open_wstream(&result.c_ptr_, c_ptr_,
+                         static_cast<git_object_size_t>(size),
+                         static_cast<git_object_t>(type)));
   return result;
 }
 
 oid odb::write(const void *data, size_t length,
                cppgit2::object::object_type type) {
   oid result;
-  if (git_odb_write(result.c_ptr(), c_ptr_, data, length,
-                    static_cast<git_object_t>(type)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_odb_write(result.c_ptr(), c_ptr_, data, length,
+                  static_cast<git_object_t>(type)));
   return result;
 }
 

--- a/src/oid.cpp
+++ b/src/oid.cpp
@@ -6,13 +6,13 @@ namespace cppgit2 {
 oid::oid() {}
 
 oid::oid(const std::string &hex_string) {
-  if (git_oid_fromstr(&c_struct_, hex_string.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_oid_fromstr(&c_struct_, hex_string.c_str()));
 }
 
 oid::oid(const std::string &hex_string, size_t length) {
-  if (git_oid_fromstrn(&c_struct_, hex_string.c_str(), length))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_oid_fromstrn(&c_struct_, hex_string.c_str(), length));
 }
 
 oid::oid(const git_oid *c_ptr) {
@@ -22,8 +22,8 @@ oid::oid(const git_oid *c_ptr) {
   if (!git_oid_tostr(const_cast<char *>(buffer.c_str()), n + 1, c_ptr))
     throw git_exception();
   // Construct from string
-  if (git_oid_fromstr(&c_struct_, buffer.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_oid_fromstr(&c_struct_, buffer.c_str()));
 }
 
 oid::oid(const unsigned char *raw) { git_oid_fromraw(&c_struct_, raw); }

--- a/src/pack_builder.cpp
+++ b/src/pack_builder.cpp
@@ -41,8 +41,8 @@ void pack_builder::for_each_object(
     return 0;
   };
 
-  if (git_packbuilder_foreach(c_ptr_, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_packbuilder_foreach(c_ptr_, callback_c, (void *)(&wrapper)));
 }
 
 oid pack_builder::hash() { return oid(git_packbuilder_hash(c_ptr_)); }
@@ -50,32 +50,32 @@ oid pack_builder::hash() { return oid(git_packbuilder_hash(c_ptr_)); }
 oid pack_builder::id() const { return oid(git_packbuilder_hash(c_ptr_)); }
 
 void pack_builder::insert_commit(const oid &commit_id) {
-  if (git_packbuilder_insert_commit(c_ptr_, commit_id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_packbuilder_insert_commit(c_ptr_, commit_id.c_ptr()));
 }
 
 void pack_builder::insert_object(const oid &commit_id,
                                  const std::string &name) {
   auto name_c = name.empty() ? nullptr : name.c_str();
-  if (git_packbuilder_insert(c_ptr_, commit_id.c_ptr(), name_c))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_packbuilder_insert(c_ptr_, commit_id.c_ptr(), name_c));
 }
 
 void pack_builder::insert_object_recursively(const oid &commit_id,
                                              const std::string &name) {
   auto name_c = name.empty() ? nullptr : name.c_str();
-  if (git_packbuilder_insert_recur(c_ptr_, commit_id.c_ptr(), name_c))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_packbuilder_insert_recur(c_ptr_, commit_id.c_ptr(), name_c));
 }
 
 void pack_builder::insert_tree(const oid &tree_id) {
-  if (git_packbuilder_insert_tree(c_ptr_, tree_id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_packbuilder_insert_tree(c_ptr_, tree_id.c_ptr()));
 }
 
 void pack_builder::insert_revwalk(const revwalk &walk) {
-  if (git_packbuilder_insert_walk(c_ptr_, walk.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_packbuilder_insert_walk(c_ptr_, walk.c_ptr_));
 }
 
 size_t pack_builder::size() const {
@@ -100,13 +100,13 @@ void pack_builder::set_progress_callback(
     return 0;
   };
 
-  if (git_packbuilder_set_callbacks(c_ptr_, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_packbuilder_set_callbacks(c_ptr_, callback_c, (void *)(&wrapper)));
 }
 
 void pack_builder::set_threads(unsigned int num_threads) {
-  if (git_packbuilder_set_threads(c_ptr_, num_threads))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_packbuilder_set_threads(c_ptr_, num_threads));
 }
 
 void pack_builder::write(
@@ -126,15 +126,15 @@ void pack_builder::write(
     return 0;
   };
 
-  if (git_packbuilder_write(c_ptr_, path.c_str(), mode, callback_c,
-                            (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_packbuilder_write(c_ptr_, path.c_str(), mode, callback_c,
+                          (void *)(&wrapper)));
 }
 
 data_buffer pack_builder::write_to_buffer() {
   git_buf result = GIT_BUF_INIT;
-  if (git_packbuilder_write_buf(&result, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_packbuilder_write_buf(&result, c_ptr_));
   return data_buffer(&result);
 }
 

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -11,20 +11,20 @@ patch::patch(const blob &old_blob, const std::string &old_as_path,
              const void *buffer, size_t buffer_length,
              const std::string &buffer_as_path, const diff::options &options) {
   owner_ = ownership::user;
-  if (git_patch_from_blob_and_buffer(&c_ptr_, old_blob.c_ptr(),
-                                     old_as_path.c_str(), buffer, buffer_length,
-                                     buffer_as_path.c_str(), options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_patch_from_blob_and_buffer(&c_ptr_, old_blob.c_ptr(),
+                                   old_as_path.c_str(), buffer, buffer_length,
+                                   buffer_as_path.c_str(), options.c_ptr()));
 }
 
 patch::patch(const blob &old_blob, const std::string &old_as_path,
              const blob &new_blob, const std::string &new_as_path,
              const diff::options &options) {
   owner_ = ownership::user;
-  if (git_patch_from_blobs(&c_ptr_, old_blob.c_ptr(), old_as_path.c_str(),
-                           new_blob.c_ptr(), new_as_path.c_str(),
-                           options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_patch_from_blobs(&c_ptr_, old_blob.c_ptr(), old_as_path.c_str(),
+                         new_blob.c_ptr(), new_as_path.c_str(),
+                         options.c_ptr()));
 }
 
 patch::patch(const void *old_buffer, size_t old_buffer_length,
@@ -32,16 +32,16 @@ patch::patch(const void *old_buffer, size_t old_buffer_length,
              size_t new_buffer_length, const std::string &new_as_path,
              const diff::options &options) {
   owner_ = ownership::user;
-  if (git_patch_from_buffers(&c_ptr_, old_buffer, old_buffer_length,
-                             old_as_path.c_str(), new_buffer, new_buffer_length,
-                             new_as_path.c_str(), options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_patch_from_buffers(&c_ptr_, old_buffer, old_buffer_length,
+                           old_as_path.c_str(), new_buffer, new_buffer_length,
+                           new_as_path.c_str(), options.c_ptr()));
 }
 
 patch::patch(const diff &diff, size_t index) {
   owner_ = ownership::user;
-  if (git_patch_from_diff(&c_ptr_, diff.c_ptr_, index))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_patch_from_diff(&c_ptr_, diff.c_ptr_, index));
 }
 
 patch::~patch() {
@@ -70,24 +70,24 @@ std::pair<diff::hunk, size_t> patch::hunk(size_t hunk_index) const {
   diff::hunk hunk_result(nullptr);
   auto hunk_result_ptr = hunk_result.c_ptr();
   size_t lines_in_hunk;
-  if (git_patch_get_hunk(&hunk_result_ptr, &lines_in_hunk, c_ptr_, hunk_index))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_patch_get_hunk(&hunk_result_ptr, &lines_in_hunk, c_ptr_, hunk_index));
   return std::pair<diff::hunk, size_t>{hunk_result, lines_in_hunk};
 }
 
 diff::line patch::line_in_hunk(size_t hunk_index, size_t line_of_hunk) const {
   diff::line result(nullptr);
   auto result_ptr = result.c_ptr();
-  if (git_patch_get_line_in_hunk(&result_ptr, c_ptr_, hunk_index, line_of_hunk))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_patch_get_line_in_hunk(&result_ptr, c_ptr_, hunk_index, line_of_hunk));
   return result;
 }
 
 std::tuple<size_t, size_t, size_t> patch::line_stats() const {
   size_t context_lines = 0, addition_lines = 0, deletion_lines = 0;
-  if (git_patch_line_stats(&context_lines, &addition_lines, &deletion_lines,
-                           c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_patch_line_stats(&context_lines, &addition_lines, &deletion_lines,
+                         c_ptr_));
   return std::tuple<size_t, size_t, size_t>{context_lines, addition_lines,
                                             deletion_lines};
 }
@@ -122,8 +122,8 @@ void patch::print(std::function<void(const diff::delta &, const diff::hunk &,
     return 0;
   };
 
-  if (git_patch_print(c_ptr_, line_callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_patch_print(c_ptr_, line_callback_c, (void *)(&wrapper)));
 }
 
 size_t patch::size(bool include_context, bool include_hunk_headers,
@@ -134,8 +134,8 @@ size_t patch::size(bool include_context, bool include_hunk_headers,
 
 data_buffer patch::to_buffer() {
   git_buf result = GIT_BUF_INIT;
-  if (git_patch_to_buf(&result, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_patch_to_buf(&result, c_ptr_));
   return data_buffer(&result);
 }
 

--- a/src/pathspec.cpp
+++ b/src/pathspec.cpp
@@ -26,8 +26,8 @@ pathspec& pathspec::operator=(pathspec&& other) {
 
 pathspec pathspec::compile(const strarray &paths) {
   pathspec result(nullptr, ownership::user);
-  if (git_pathspec_new(&result.c_ptr_, paths.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_pathspec_new(&result.c_ptr_, paths.c_ptr()));
   return result;
 }
 
@@ -35,9 +35,9 @@ pathspec::match_list pathspec::match_diff(const diff &diff,
                                           pathspec::flag flags) {
   git_pathspec_match_list **result_c =
       (git_pathspec_match_list **)malloc(sizeof(git_pathspec_match_list *));
-  if (git_pathspec_match_diff(result_c, diff.c_ptr_,
-                              static_cast<uint32_t>(flags), c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_pathspec_match_diff(result_c, diff.c_ptr_,
+                            static_cast<uint32_t>(flags), c_ptr_));
   return pathspec::match_list(*result_c);
 }
 
@@ -45,9 +45,9 @@ pathspec::match_list pathspec::match_index(const index &index,
                                            pathspec::flag flags) {
   git_pathspec_match_list **result_c =
       (git_pathspec_match_list **)malloc(sizeof(git_pathspec_match_list *));
-  if (git_pathspec_match_index(result_c, index.c_ptr_,
-                               static_cast<uint32_t>(flags), c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_pathspec_match_index(result_c, index.c_ptr_,
+                             static_cast<uint32_t>(flags), c_ptr_));
   return pathspec::match_list(*result_c);
 }
 
@@ -55,9 +55,9 @@ pathspec::match_list pathspec::match_tree(const tree &tree,
                                           pathspec::flag flags) {
   git_pathspec_match_list **result_c =
       (git_pathspec_match_list **)malloc(sizeof(git_pathspec_match_list *));
-  if (git_pathspec_match_tree(result_c, tree.c_ptr_,
-                              static_cast<uint32_t>(flags), c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_pathspec_match_tree(result_c, tree.c_ptr_,
+                            static_cast<uint32_t>(flags), c_ptr_));
   return pathspec::match_list(*result_c);
 }
 
@@ -65,9 +65,9 @@ pathspec::match_list pathspec::match_workdir(const repository &repo,
                                              pathspec::flag flags) {
   git_pathspec_match_list **result_c =
       (git_pathspec_match_list **)malloc(sizeof(git_pathspec_match_list *));
-  if (git_pathspec_match_workdir(result_c, repo.c_ptr_,
-                                 static_cast<uint32_t>(flags), c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_pathspec_match_workdir(result_c, repo.c_ptr_,
+                               static_cast<uint32_t>(flags), c_ptr_));
   return pathspec::match_list(*result_c);
 }
 

--- a/src/rebase.cpp
+++ b/src/rebase.cpp
@@ -25,37 +25,37 @@ rebase& rebase::operator=(rebase&& other) {
 }
 
 void rebase::abort() {
-  if (git_rebase_abort(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_rebase_abort(c_ptr_));
 }
 
 oid rebase::commit(const signature &author, const signature &committer,
                    const std::string &message_encoding,
                    const std::string &message) {
   oid result;
-  if (git_rebase_commit(result.c_ptr(), c_ptr_, author.c_ptr(),
-                        committer.c_ptr(), message_encoding.c_str(),
-                        message.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_rebase_commit(result.c_ptr(), c_ptr_, author.c_ptr(),
+                      committer.c_ptr(), message_encoding.c_str(),
+                      message.c_str()));
   return result;
 }
 
 void rebase::finish(const signature &sig) {
-  if (git_rebase_finish(c_ptr_, sig.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_rebase_finish(c_ptr_, sig.c_ptr()));
 }
 
 cppgit2::index rebase::index() {
   cppgit2::index result(nullptr, ownership::user);
-  if (git_rebase_inmemory_index(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_rebase_inmemory_index(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 rebase::operation rebase::next() {
   operation result;
-  if (git_rebase_next(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_rebase_next(&result.c_ptr_, c_ptr_));
   return result;
 }
 

--- a/src/reference.cpp
+++ b/src/reference.cpp
@@ -34,13 +34,13 @@ reference reference::copy() const {
 }
 
 reference::reference(reference const& other) : owner_(ownership::user){
-  if (git_reference_dup(&c_ptr_, other.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_reference_dup(&c_ptr_, other.c_ptr_));
 }
 
 void reference::delete_reference(reference &ref) {
-  if (git_reference_delete(ref.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_reference_delete(ref.c_ptr_));
 }
 
 bool reference::is_branch() const { return git_reference_is_branch(c_ptr_); }
@@ -66,9 +66,9 @@ std::string reference::name() const {
 std::string reference::normalize_name(size_t length, const std::string &name,
                                       reference::format flags) {
   char *buffer = (char *)malloc(length * sizeof(char));
-  if (git_reference_normalize_name(buffer, length, name.c_str(),
-                                   static_cast<unsigned int>(flags)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_reference_normalize_name(buffer, length, name.c_str(),
+                                 static_cast<unsigned int>(flags)));
   std::string result{""};
   if (buffer)
     result = std::string(buffer);
@@ -90,42 +90,42 @@ repository reference::owner() const {
 
 object reference::peel_until(object::object_type type) {
   object result(nullptr, ownership::user);
-  if (git_reference_peel(&result.c_ptr_, c_ptr_,
-                         static_cast<git_object_t>(type)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_reference_peel(&result.c_ptr_, c_ptr_,
+                       static_cast<git_object_t>(type)));
   return result;
 }
 
 reference reference::rename(const std::string &new_name, bool force,
                             const std::string &log_message) {
   reference result(nullptr, ownership::user);
-  if (git_reference_rename(&result.c_ptr_, c_ptr_, new_name.c_str(), force,
-                           log_message.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_reference_rename(&result.c_ptr_, c_ptr_, new_name.c_str(), force,
+                         log_message.c_str()));
   return result;
 }
 
 reference reference::resolve() {
   reference result(nullptr, ownership::user);
-  if (git_reference_resolve(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_reference_resolve(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 reference reference::set_target(const oid &id, const std::string &log_message) {
   reference result(nullptr, ownership::user);
-  if (git_reference_set_target(&result.c_ptr_, c_ptr_, id.c_ptr(),
-                               log_message.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_reference_set_target(&result.c_ptr_, c_ptr_, id.c_ptr(),
+                             log_message.c_str()));
   return result;
 }
 
 reference reference::set_symbolic_target(const std::string &target,
                                          const std::string &log_message) {
   reference result(nullptr, ownership::user);
-  if (git_reference_symbolic_set_target(&result.c_ptr_, c_ptr_, target.c_str(),
-                                        log_message.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_reference_symbolic_set_target(&result.c_ptr_, c_ptr_, target.c_str(),
+                                      log_message.c_str()));
   return result;
 }
 

--- a/src/reflog.cpp
+++ b/src/reflog.cpp
@@ -26,14 +26,14 @@ reflog& reflog::operator=(reflog&& other) {
 }
 
 void reflog::remove(size_t index, bool rewrite_previous_entry) {
-  if (git_reflog_drop(c_ptr_, index, rewrite_previous_entry))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_reflog_drop(c_ptr_, index, rewrite_previous_entry));
 }
 
 void reflog::append(const oid &id, const signature &committer,
                     const std::string &message) {
-  if (git_reflog_append(c_ptr_, id.c_ptr(), committer.c_ptr(), message.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_reflog_append(c_ptr_, id.c_ptr(), committer.c_ptr(), message.c_str()));
 }
 
 reflog::entry reflog::operator[](size_t index) const {
@@ -41,8 +41,8 @@ reflog::entry reflog::operator[](size_t index) const {
 }
 
 void reflog::write_to_disk() {
-  if (git_reflog_write(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_reflog_write(c_ptr_));
 }
 
 size_t reflog::size() const { return git_reflog_entrycount(c_ptr_); }

--- a/src/refspec.cpp
+++ b/src/refspec.cpp
@@ -43,16 +43,16 @@ bool refspec::is_force_update_enabled() const {
 
 refspec refspec::parse(const std::string &input, bool is_fetch) {
   refspec result(nullptr, ownership::user);
-  if (git_refspec_parse(&result.c_ptr_, input.c_str(), is_fetch))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_refspec_parse(&result.c_ptr_, input.c_str(), is_fetch));
   return result;
 }
 
 data_buffer
 refspec::transform_target_to_source_reference(const std::string &name) {
   git_buf result = GIT_BUF_INIT;
-  if (git_refspec_rtransform(&result, c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_refspec_rtransform(&result, c_ptr_, name.c_str()));
   return data_buffer(&result);
 }
 
@@ -72,8 +72,8 @@ std::string refspec::to_string() const {
 
 data_buffer refspec::transform_reference(const std::string &name) {
   git_buf result;
-  if (git_refspec_transform(&result, c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_refspec_transform(&result, c_ptr_, name.c_str()));
   return data_buffer(&result);
 }
 

--- a/src/remote.cpp
+++ b/src/remote.cpp
@@ -34,10 +34,10 @@ void remote::connect(connection_direction direction,
                      const callbacks &remote_callbacks,
                      const proxy::options &proxy_options,
                      const strarray &custom_headers) {
-  if (git_remote_connect(c_ptr_, static_cast<git_direction>(direction),
-                         remote_callbacks.c_ptr(), proxy_options.c_ptr(),
-                         custom_headers.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_connect(c_ptr_, static_cast<git_direction>(direction),
+                       remote_callbacks.c_ptr(), proxy_options.c_ptr(),
+                       custom_headers.c_ptr()));
 }
 
 cppgit2::repository remote::create_options::repository() const {
@@ -53,61 +53,61 @@ remote remote::copy() const {
 }
 
 remote::remote(remote const& other) : owner_(ownership::user){
-  if (git_remote_dup(&c_ptr_, other.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_dup(&c_ptr_, other.c_ptr_));
 }
 
 remote remote::create_detached_remote(const std::string &url) {
   remote result(nullptr, ownership::user);
-  if (git_remote_create_detached(&result.c_ptr_, url.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_create_detached(&result.c_ptr_, url.c_str()));
   return result;
 }
 
 remote remote::create_remote(const std::string &url,
                              const create_options &options) {
   remote result(nullptr, ownership::user);
-  if (git_remote_create_with_opts(&result.c_ptr_, url.c_str(), options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_create_with_opts(&result.c_ptr_, url.c_str(), options.c_ptr()));
   return result;
 }
 
 data_buffer remote::default_branch() const {
   git_buf result = GIT_BUF_INIT;
-  if (git_remote_default_branch(&result, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_default_branch(&result, c_ptr_));
   return data_buffer(&result);
 }
 
 void remote::disconnect() {
-  if (git_remote_disconnect(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_disconnect(c_ptr_));
 }
 
 void remote::download(const strarray &refspecs, const fetch::options &options) {
-  if (git_remote_download(c_ptr_, refspecs.c_ptr(), options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_download(c_ptr_, refspecs.c_ptr(), options.c_ptr()));
 }
 
 void remote::fetch_(const strarray &refspecs,
                         const std::string &reflog_message,
                         const fetch::options &options) {
-  if (git_remote_fetch(c_ptr_, refspecs.c_ptr(), options.c_ptr(),
-                       reflog_message.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_fetch(c_ptr_, refspecs.c_ptr(), options.c_ptr(),
+                     reflog_message.c_str()));
 }
 
 strarray remote::fetch_refspec() const {
   strarray result;
-  if (git_remote_get_fetch_refspecs(&result.c_struct_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_get_fetch_refspecs(&result.c_struct_, c_ptr_));
   return result;
 }
 
 strarray remote::push_refspec() const {
   strarray result;
-  if (git_remote_get_push_refspecs(&result.c_struct_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_get_push_refspecs(&result.c_struct_, c_ptr_));
   return result;
 }
 
@@ -119,8 +119,8 @@ std::vector<remote::head> remote::reference_advertisement_list() {
   const git_remote_head *head_ptr = nullptr;
   const git_remote_head **head_ptr_ptr = &head_ptr;
   size_t size = 0;
-  if (git_remote_ls(&head_ptr_ptr, &size, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_ls(&head_ptr_ptr, &size, c_ptr_));
 
   std::vector<head> result;
   for (size_t i = 0; i < size; ++i)
@@ -138,18 +138,18 @@ repository remote::owner() const {
 }
 
 void remote::prune(const callbacks &remote_callbacks) {
-  if (git_remote_prune(c_ptr_, remote_callbacks.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_prune(c_ptr_, remote_callbacks.c_ptr()));
 }
 
 void remote::prune_references() {
-  if (git_remote_prune_refs(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_prune_refs(c_ptr_));
 }
 
 void remote::push(const strarray &refspecs, const push::options &options) {
-  if (git_remote_push(c_ptr_, refspecs.c_ptr(), options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_push(c_ptr_, refspecs.c_ptr(), options.c_ptr()));
 }
 
 std::string remote::push_url() const {
@@ -168,24 +168,24 @@ indexer::progress remote::stats() const {
 }
 
 void remote::stop() {
-  if (git_remote_stop(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_stop(c_ptr_));
 }
 
 void remote::update_tips(const callbacks &remote_callbacks,
                          bool update_fetchhead,
                          fetch::options::autotag download_tags,
                          const std::string &reflog_message) {
-  if (git_remote_update_tips(
-          c_ptr_, remote_callbacks.c_ptr(), update_fetchhead,
-          static_cast<git_remote_autotag_option_t>(download_tags),
-          reflog_message.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_update_tips(
+        c_ptr_, remote_callbacks.c_ptr(), update_fetchhead,
+        static_cast<git_remote_autotag_option_t>(download_tags),
+        reflog_message.c_str()));
 }
 
 void remote::upload(const strarray &refspecs, const push::options &options) {
-  if (git_remote_upload(c_ptr_, refspecs.c_ptr(), options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_remote_upload(c_ptr_, refspecs.c_ptr(), options.c_ptr()));
 }
 
 std::string remote::url() const {

--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -24,48 +24,48 @@ repository& repository::operator=(repository&& other) {
 
 repository repository::init(const std::string &path, bool is_bare) {
   repository result(nullptr);
-  if (git_repository_init(&result.c_ptr_, path.c_str(), is_bare))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_init(&result.c_ptr_, path.c_str(), is_bare));
   return result;
 }
 
 repository repository::init_ext(const std::string &repo_path,
                                 const init_options &options) {
   repository result(nullptr);
-  if (git_repository_init_ext(&result.c_ptr_, repo_path.c_str(),
-                              options.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_init_ext(&result.c_ptr_, repo_path.c_str(),
+                              options.c_ptr_));
   return result;
 }
 
 repository repository::open(const std::string &path) {
   repository result(nullptr);
-  if (git_repository_open(&result.c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_open(&result.c_ptr_, path.c_str()));
   return result;
 }
 
 repository repository::open_bare(const std::string &path) {
   repository result(nullptr);
-  if (git_repository_open_bare(&result.c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_open_bare(&result.c_ptr_, path.c_str()));
   return result;
 }
 
 repository repository::open_ext(const std::string &path, open_flag flags,
                                 const std::string &ceiling_dirs) {
   repository result(nullptr);
-  if (git_repository_open_ext(&result.c_ptr_, path.c_str(),
+  git_exception::throw_nonzero(
+      git_repository_open_ext(&result.c_ptr_, path.c_str(),
                               static_cast<unsigned int>(flags),
-                              ceiling_dirs.c_str()))
-    throw git_exception();
+                              ceiling_dirs.c_str()));
   return result;
 }
 
 repository repository::open_from_worktree(const worktree &wt) {
   repository result(nullptr);
-  if (git_repository_open_from_worktree(&result.c_ptr_, wt.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_open_from_worktree(&result.c_ptr_, wt.c_ptr_));
   return result;
 }
 
@@ -73,9 +73,9 @@ repository repository::clone(const std::string &url,
                              const std::string &local_path,
                              const clone::options &options) {
   repository result;
-  if (git_clone(&result.c_ptr_, url.c_str(), local_path.c_str(),
-                options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_clone(&result.c_ptr_, url.c_str(), local_path.c_str(),
+                options.c_ptr()));
   return result;
 }
 
@@ -86,13 +86,8 @@ std::string repository::path() const {
 bool repository::is_bare() const { return git_repository_is_bare(c_ptr_); }
 
 bool repository::is_empty() const {
-  auto ret = git_repository_is_empty(c_ptr_);
-  if (ret == 1)
-    return true;
-  else if (ret == 0)
-    return false;
-  else
-    throw git_exception();
+  return git_exception::throw_nonbool(
+      git_repository_is_empty(c_ptr_));
 }
 
 bool repository::is_shallow() const {
@@ -113,30 +108,30 @@ std::string repository::commondir() const {
 
 cppgit2::config repository::config() const {
   cppgit2::config result(nullptr, ownership::user);
-  if (git_repository_config(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_config(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 cppgit2::config repository::config_snapshot() const {
   cppgit2::config result(nullptr, ownership::user);
-  if (git_repository_config_snapshot(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_config_snapshot(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 void repository::detach_head() const {
-  if (git_repository_detach_head(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_detach_head(c_ptr_));
 }
 
 std::string repository::discover_path(const std::string &start_path,
                                       bool across_fs,
                                       const std::string &ceiling_dirs) {
   git_buf buffer = GIT_BUF_INIT;
-  if (git_repository_discover(&buffer, start_path.c_str(), across_fs,
-                              ceiling_dirs.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_discover(&buffer, start_path.c_str(), across_fs,
+                              ceiling_dirs.c_str()));
   return data_buffer(&buffer).to_string();
 }
 
@@ -165,8 +160,8 @@ void repository::for_each_fetch_head(
     return 0;
   };
 
-  if (git_repository_fetchhead_foreach(c_ptr_, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_fetchhead_foreach(c_ptr_, callback_c, (void *)(&wrapper)));
 }
 
 void repository::for_each_merge_head(std::function<void(const oid &)> visitor) const {
@@ -183,8 +178,8 @@ void repository::for_each_merge_head(std::function<void(const oid &)> visitor) c
     return 0;
   };
 
-  if (git_repository_mergehead_foreach(c_ptr_, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_mergehead_foreach(c_ptr_, callback_c, (void *)(&wrapper)));
 }
 
 std::string repository::namespace_() const {
@@ -192,15 +187,17 @@ std::string repository::namespace_() const {
   if (ret)
     return std::string(ret);
   else
-    throw git_exception("namespace directory does not exist");
+    throw git_exception("namespace directory does not exist",
+                        git_exception::error_class::invalid,
+                        git_exception::error_code::invalid);
 }
 
 oid repository::hashfile(const std::string &path, object::object_type type,
                          const std::string &as_path) const {
   oid result;
-  if (git_repository_hashfile(result.c_ptr(), c_ptr_, path.c_str(),
-                              static_cast<git_object_t>(type), as_path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_hashfile(result.c_ptr(), c_ptr_, path.c_str(),
+                              static_cast<git_object_t>(type), as_path.c_str()));
   return result;
 }
 
@@ -210,75 +207,60 @@ oid repository::hashfile(const std::string &path, object::object_type type) cons
 
 reference repository::head() const {
   reference result(nullptr, ownership::user);
-  if (git_repository_head(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_head(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 reference repository::head_for_worktree(const std::string &name) const {
   reference result(nullptr, ownership::user);
-  if (git_repository_head_for_worktree(&result.c_ptr_, c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_head_for_worktree(&result.c_ptr_, c_ptr_, name.c_str()));
   return result;
 }
 
 bool repository::is_head_detached() const {
-  auto ret = git_repository_head_detached(c_ptr_);
-  if (ret == 0)
-    return false;
-  else if (ret == 1)
-    return true;
-  else
-    throw git_exception();
+  return git_exception::throw_nonbool(
+      git_repository_head_detached(c_ptr_));
 }
 
 bool repository::is_head_detached_for_worktree(const std::string &path) {
-  auto ret = git_repository_head_detached_for_worktree(c_ptr_, path.c_str());
-  if (ret == 0)
-    return false;
-  else if (ret == 1)
-    return true;
-  else
-    throw git_exception();
+  return git_exception::throw_nonbool(
+      git_repository_head_detached_for_worktree(c_ptr_, path.c_str()));
 }
 
 bool repository::is_head_unborn() const {
-  auto ret = git_repository_head_unborn(c_ptr_);
-  if (ret == 0)
-    return false;
-  else if (ret == 1)
-    return true;
-  else
-    throw git_exception();
+  return git_exception::throw_nonbool(
+      git_repository_head_unborn(c_ptr_));
 }
 
 std::pair<std::string, std::string> repository::identity() const {
   const char *name_c, *email_c;
-  if (git_repository_ident(&name_c, &email_c, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_ident(&name_c, &email_c, c_ptr_));
   return std::pair<std::string, std::string>{name_c ? name_c : "",
                                              email_c ? email_c : ""};
 }
 
 cppgit2::index repository::index() const {
   cppgit2::index result(nullptr, ownership::user);
-  if (git_repository_index(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_index(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 std::string repository::path(repository::item item) const {
   git_buf buffer = GIT_BUF_INIT;
-  if (git_repository_item_path(&buffer, c_ptr_,
-                               static_cast<git_repository_item_t>(item)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_item_path(&buffer, c_ptr_,
+                               static_cast<git_repository_item_t>(item)));
   return data_buffer(&buffer).to_string();
 }
 
 std::string repository::message() const {
   git_buf buffer = GIT_BUF_INIT;
-  if (git_repository_message(&buffer, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_message(&buffer, c_ptr_));
     
   return data_buffer(&buffer).to_string();
 }
@@ -287,57 +269,57 @@ void repository::remove_message() const { git_repository_message_remove(c_ptr_);
 
 cppgit2::odb repository::odb() const {
   cppgit2::odb result(nullptr, ownership::user);
-  if (git_repository_odb(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_odb(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 cppgit2::refdb repository::refdb() const {
   cppgit2::refdb result(nullptr, ownership::user);
-  if (git_repository_refdb(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_refdb(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 void repository::set_head(const std::string &refname) const {
-  if (git_repository_set_head(c_ptr_, refname.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_set_head(c_ptr_, refname.c_str()));
 }
 
 void repository::set_head_detached(const oid &commitish) const {
-  if (git_repository_set_head_detached(c_ptr_, commitish.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_set_head_detached(c_ptr_, commitish.c_ptr()));
 }
 
 void repository::set_head_detached(const annotated_commit &commitish) const {
-  if (git_repository_set_head_detached_from_annotated(c_ptr_, commitish.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_set_head_detached_from_annotated(c_ptr_, commitish.c_ptr_));
 }
 
 void repository::set_identity(const std::string &name,
                               const std::string &email) const {
-  if (git_repository_set_ident(c_ptr_, name.c_str(), email.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_set_ident(c_ptr_, name.c_str(), email.c_str()));
 }
 
 void repository::unset_identity() const {
-  if (git_repository_set_ident(c_ptr_, nullptr, nullptr))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_set_ident(c_ptr_, nullptr, nullptr));
 }
 
 void repository::set_namespace(const std::string &namespace_) const {
-  if (git_repository_set_namespace(c_ptr_, namespace_.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_set_namespace(c_ptr_, namespace_.c_str()));
 }
 
 void repository::set_workdir(const std::string &workdir, bool update_gitlink) const {
-  if (git_repository_set_workdir(c_ptr_, workdir.c_str(), update_gitlink))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_set_workdir(c_ptr_, workdir.c_str(), update_gitlink));
 }
 
 void repository::cleanup_state() const {
-  if (git_repository_state_cleanup(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_state_cleanup(c_ptr_));
 }
 
 repository::repository_state repository::state() const {
@@ -377,14 +359,16 @@ std::string repository::workdir() const {
   if (ret) {
     return std::string(ret);
   } else {
-    throw git_exception("working directory does not exist");
+    throw git_exception("working directory does not exist",
+                        git_exception::error_class::invalid,
+                        git_exception::error_code::invalid);
   }
 }
 
 repository repository::wrap_odb(const cppgit2::odb &odb) {
   repository result(nullptr);
-  if (git_repository_wrap_odb(&result.c_ptr_, odb.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_repository_wrap_odb(&result.c_ptr_, odb.c_ptr_));
   return result;
 }
 
@@ -395,62 +379,62 @@ repository::create_annotated_commit(const std::string &branch_name,
                                     const std::string &remote_url,
                                     const oid &id) const {
   annotated_commit result(nullptr, ownership::user);
-  if (git_annotated_commit_from_fetchhead(&result.c_ptr_, c_ptr_,
+  git_exception::throw_nonzero(
+      git_annotated_commit_from_fetchhead(&result.c_ptr_, c_ptr_,
                                           branch_name.c_str(),
-                                          remote_url.c_str(), id.c_ptr()))
-    throw git_exception();
+                                          remote_url.c_str(), id.c_ptr()));
   return result;
 }
 
 annotated_commit
 repository::create_annotated_commit(const std::string &revspec) const {
   annotated_commit result(nullptr, ownership::user);
-  if (git_annotated_commit_from_revspec(&result.c_ptr_, c_ptr_,
-                                        revspec.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_annotated_commit_from_revspec(&result.c_ptr_, c_ptr_,
+                                        revspec.c_str()));
   return result;
 }
 
 annotated_commit repository::create_annotated_commit(const reference &ref) const {
   annotated_commit result(nullptr, ownership::user);
-  if (git_annotated_commit_from_ref(&result.c_ptr_, c_ptr_, ref.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_annotated_commit_from_ref(&result.c_ptr_, c_ptr_, ref.c_ptr()));
   return result;
 }
 
 annotated_commit repository::lookup_annotated_commit(const oid &id) const {
   annotated_commit result(nullptr, ownership::user);
-  if (git_annotated_commit_lookup(&result.c_ptr_, c_ptr_, id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_annotated_commit_lookup(&result.c_ptr_, c_ptr_, id.c_ptr()));
   return result;
 }
 
 void repository::apply_diff(const diff &diff, apply::location location,
                             const apply::options &options) const {
-  if (git_apply(c_ptr_, const_cast<git_diff *>(diff.c_ptr()),
-                static_cast<git_apply_location_t>(location), options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_apply(c_ptr_, const_cast<git_diff *>(diff.c_ptr()),
+                static_cast<git_apply_location_t>(location), options.c_ptr()));
 }
 
 cppgit2::index repository::apply_diff(const tree &preimage, const diff &diff,
                                       const apply::options &options) const {
   git_index *result; // the postimage of the application
-  if (git_apply_to_tree(&result, c_ptr_,
+  git_exception::throw_nonzero(
+      git_apply_to_tree(&result, c_ptr_,
                         const_cast<git_tree *>(preimage.c_ptr()),
-                        const_cast<git_diff *>(diff.c_ptr()), options.c_ptr()))
-    throw git_exception();
+                        const_cast<git_diff *>(diff.c_ptr()), options.c_ptr()));
   return cppgit2::index(result, ownership::user);
 }
 
 void repository::add_attributes_macro(const std::string &name,
                                       const std::string &values) const {
-  if (git_attr_add_macro(c_ptr_, name.c_str(), values.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_attr_add_macro(c_ptr_, name.c_str(), values.c_str()));
 }
 
 void repository::flush_attributes_cache() const {
-  if (git_attr_cache_flush(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_attr_cache_flush(c_ptr_));
 }
 
 void repository::for_each_attribute(
@@ -470,18 +454,18 @@ void repository::for_each_attribute(
     return 0;
   };
 
-  if (git_attr_foreach(c_ptr_, static_cast<uint32_t>(flags), path.c_str(),
-                       callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_attr_foreach(c_ptr_, static_cast<uint32_t>(flags), path.c_str(),
+                       callback_c, (void *)(&wrapper)));
 }
 
 std::string repository::lookup_attribute(attribute::flag flags,
                                          const std::string &path,
                                          const std::string &name) const {
   const char *result;
-  if (git_attr_get(&result, c_ptr_, static_cast<uint32_t>(flags), path.c_str(),
-                   name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_attr_get(&result, c_ptr_, static_cast<uint32_t>(flags), path.c_str(),
+                   name.c_str()));
   if (result)
     return std::string(result);
   else
@@ -499,9 +483,9 @@ repository::lookup_multiple_attributes(attribute::flag flags,
   for (auto &name : names)
     names_c.push_back(name.c_str());
 
-  if (git_attr_get_many(values, c_ptr_, static_cast<uint32_t>(flags),
-                        path.c_str(), names.size(), names_c.data()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_attr_get_many(values, c_ptr_, static_cast<uint32_t>(flags),
+                        path.c_str(), names.size(), names_c.data()));
 
   std::vector<std::string> result;
   for (size_t i = 0; i < names.size(); ++i) {
@@ -518,54 +502,54 @@ repository::lookup_multiple_attributes(attribute::flag flags,
 blame repository::blame_file(const std::string &path,
                              blame::options options) const {
   blame result(nullptr, ownership::user);
-  if (git_blame_file(&result.c_ptr_, c_ptr_, path.c_str(), options.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_blame_file(&result.c_ptr_, c_ptr_, path.c_str(), options.c_ptr_));
   return result;
 }
 
 oid repository::create_blob_from_buffer(const std::string &buffer) const {
   oid result;
-  if (git_blob_create_frombuffer(result.c_ptr(), c_ptr_, buffer.c_str(),
-                                 buffer.size()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_blob_create_frombuffer(result.c_ptr(), c_ptr_, buffer.c_str(),
+                                 buffer.size()));
   return result;
 }
 
 oid repository::create_blob_from_disk(const std::string &path) const {
   oid result;
-  if (git_blob_create_fromdisk(result.c_ptr(), c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_blob_create_fromdisk(result.c_ptr(), c_ptr_, path.c_str()));
   return result;
 }
 
 oid repository::create_blob_from_workdir(const std::string &relative_path) const {
   oid result;
-  if (git_blob_create_fromworkdir(result.c_ptr(), c_ptr_,
-                                  relative_path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_blob_create_fromworkdir(result.c_ptr(), c_ptr_,
+                                  relative_path.c_str()));
   return result;
 }
 
 blob repository::lookup_blob(const oid &id) const {
   blob result;
-  if (git_blob_lookup(&result.c_ptr_, c_ptr_, id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_blob_lookup(&result.c_ptr_, c_ptr_, id.c_ptr()));
   return result;
 }
 
 blob repository::lookup_blob(const oid &id, size_t len) const {
   blob result;
-  if (git_blob_lookup_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), len))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_blob_lookup_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), len));
   return result;
 }
 
 reference repository::create_branch(const std::string &branch_name,
                                     const commit &target, bool force) const {
   reference result(nullptr, ownership::user);
-  if (git_branch_create(&result.c_ptr_, c_ptr_, branch_name.c_str(),
-                        target.c_ptr(), force))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_create(&result.c_ptr_, c_ptr_, branch_name.c_str(),
+                        target.c_ptr(), force));
   return result;
 }
 
@@ -573,15 +557,15 @@ reference repository::create_branch(const std::string &branch_name,
                                     const annotated_commit &commit,
                                     bool force) const {
   reference result(nullptr, ownership::user);
-  if (git_branch_create_from_annotated(
-          &result.c_ptr_, c_ptr_, branch_name.c_str(), commit.c_ptr(), force))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_create_from_annotated(
+          &result.c_ptr_, c_ptr_, branch_name.c_str(), commit.c_ptr(), force));
   return result;
 }
 
 void repository::delete_branch(const reference &ref) const {
-  if (git_branch_delete(ref.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_delete(ref.c_ptr_));
 }
 
 void repository::delete_branch(const std::string &branch_name,
@@ -590,13 +574,8 @@ void repository::delete_branch(const std::string &branch_name,
 }
 
 bool repository::is_branch_checked_out(const reference &ref) const {
-  auto ret = git_branch_is_checked_out(ref.c_ptr());
-  if (ret == 1)
-    return true;
-  else if (ret == 0)
-    return false;
-  else
-    throw git_exception();
+  return git_exception::throw_nonbool(
+    git_branch_is_checked_out(ref.c_ptr()));
 }
 
 bool repository::is_branch_checked_out(const std::string &branch_name,
@@ -607,13 +586,8 @@ bool repository::is_branch_checked_out(const std::string &branch_name,
 bool repository::is_head_pointing_to_branch(const reference &ref) const {
   // 1 if HEAD points at the branch, 0 if it isn't, or a negative value as an
   // error code.
-  auto ret = git_branch_is_head(ref.c_ptr());
-  if (ret == 1)
-    return true;
-  else if (ret == 0)
-    return false;
-  else
-    throw git_exception();
+  return git_exception::throw_nonbool(
+    git_branch_is_head(ref.c_ptr()));
 }
 
 bool repository::is_head_pointing_to_branch(const std::string &branch_name,
@@ -625,9 +599,9 @@ reference repository::rename_branch(const reference &ref,
                                     const std::string &new_branch_name,
                                     bool force) const {
   reference result(nullptr, ownership::user);
-  if (git_branch_move(&result.c_ptr_, ref.c_ptr_, new_branch_name.c_str(),
-                      force))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_move(&result.c_ptr_, ref.c_ptr_, new_branch_name.c_str(),
+                      force));
   return result;
 }
 
@@ -641,27 +615,25 @@ reference repository::rename_branch(const std::string &branch_name,
 
 std::string repository::branch_name(const reference &branch) const {
   const char *name;
-  auto ret = git_branch_name(&name, branch.c_ptr());
-  if (ret == 0) {
-    if (name)
-      return std::string(name);
-    else
-      return "";
-  } else
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_name(&name, branch.c_ptr()));
+  if (name)
+    return std::string(name);
+  else
+    return "";
 }
 
 std::string repository::branch_remote_name(const std::string &refname) const {
   git_buf buf = GIT_BUF_INIT;
-  if (git_branch_remote_name(&buf, c_ptr_, refname.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_remote_name(&buf, c_ptr_, refname.c_str()));
   return data_buffer(&buf).to_string();
 }
 
 void repository::set_branch_upstream(const reference &ref,
                                      const std::string &upstream_name) const {
-  if (git_branch_set_upstream(ref.c_ptr_, upstream_name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_set_upstream(ref.c_ptr_, upstream_name.c_str()));
 }
 
 void repository::set_branch_upstream(const std::string &branch_name,
@@ -671,8 +643,8 @@ void repository::set_branch_upstream(const std::string &branch_name,
 }
 
 void repository::unset_branch_upstream(const reference &ref) const {
-  if (git_branch_set_upstream(ref.c_ptr_, nullptr))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_set_upstream(ref.c_ptr_, nullptr));
 }
 
 void repository::unset_branch_upstream(const std::string &branch_name) const {
@@ -682,8 +654,8 @@ void repository::unset_branch_upstream(const std::string &branch_name) const {
 
 reference repository::branch_upstream(const reference &local_branch) const {
   reference result(nullptr, ownership::user);
-  if (git_branch_upstream(&result.c_ptr_, local_branch.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_upstream(&result.c_ptr_, local_branch.c_ptr()));
   return result;
 }
 
@@ -694,25 +666,25 @@ reference repository::branch_upstream(const std::string &local_branch_name) cons
 
 std::string repository::branch_upstream_name(const std::string &refname) const {
   git_buf buf = GIT_BUF_INIT;
-  if (git_branch_upstream_name(&buf, c_ptr_, refname.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_upstream_name(&buf, c_ptr_, refname.c_str()));
   return data_buffer(&buf).to_string();
 }
 
 std::string
 repository::branch_upstream_remote(const std::string &refname) const {
   git_buf buf = GIT_BUF_INIT;
-  if (git_branch_upstream_remote(&buf, c_ptr_, refname.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_upstream_remote(&buf, c_ptr_, refname.c_str()));
   return data_buffer(&buf).to_string();
 }
 
 reference repository::lookup_branch(const std::string &branch_name,
                                     branch::branch_type branch_type) const {
   reference result(nullptr, ownership::user);
-  if (git_branch_lookup(&result.c_ptr_, c_ptr_, branch_name.c_str(),
-                        static_cast<git_branch_t>(branch_type)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_branch_lookup(&result.c_ptr_, c_ptr_, branch_name.c_str(),
+                        static_cast<git_branch_t>(branch_type)));
   return result;
 }
 
@@ -736,27 +708,27 @@ void repository::checkout_head(const checkout::options &options) const {
   // checkout conflicts since your working directory would then appear to be
   // dirty. Instead, checkout the target of the branch and then update HEAD
   // using repository.set_head to point to the branch you checked out.
-  if (git_checkout_head(c_ptr_, options.c_ptr())) // options may be NULL
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_checkout_head(c_ptr_, options.c_ptr())); // options may be NULL
 }
 
 void repository::checkout_index(const cppgit2::index &index,
                                 const checkout::options &options) const {
-  if (git_checkout_index(c_ptr_, const_cast<git_index *>(index.c_ptr()),
-                         options.c_ptr())) // index & options may be NULL
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_checkout_index(c_ptr_, const_cast<git_index *>(index.c_ptr()),
+                         options.c_ptr())); // index & options may be NULL
 }
 
 void repository::checkout_tree(const object &treeish,
                                const checkout::options &options) const {
-  if (git_checkout_tree(c_ptr_, treeish.c_ptr(), options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_checkout_tree(c_ptr_, treeish.c_ptr(), options.c_ptr()));
 }
 
 void repository::cherrypick_commit(const commit &commit,
                                    const cherrypick::options &options) const {
-  if (git_cherrypick(c_ptr_, commit.c_ptr_, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_cherrypick(c_ptr_, commit.c_ptr_, options.c_ptr()));
 }
 
 cppgit2::index
@@ -764,9 +736,9 @@ repository::cherrypick_commit(const commit &cherrypick_commit,
                               const commit &our_commit, unsigned int mainline,
                               const merge::options &merge_options) const {
   cppgit2::index result(nullptr, ownership::user);
-  if (git_cherrypick_commit(&result.c_ptr_, c_ptr_, cherrypick_commit.c_ptr_,
-                            our_commit.c_ptr_, mainline, merge_options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_cherrypick_commit(&result.c_ptr_, c_ptr_, cherrypick_commit.c_ptr_,
+                            our_commit.c_ptr_, mainline, merge_options.c_ptr()));
   return result;
 }
 
@@ -784,10 +756,10 @@ oid repository::create_commit(const std::string &update_ref,
   for (auto &p : parents) {
     parents_c.push_back(p.c_ptr());
   }
-  if (git_commit_create(result.c_ptr(), c_ptr_, update_ref_c, author.c_ptr(),
+  git_exception::throw_nonzero(
+      git_commit_create(result.c_ptr(), c_ptr_, update_ref_c, author.c_ptr(),
                         committer.c_ptr(), message_encoding_c, message.c_str(),
-                        tree.c_ptr(), parents.size(), parents_c.data()))
-    throw git_exception();
+                        tree.c_ptr(), parents.size(), parents_c.data()));
   return result;
 }
 
@@ -804,11 +776,11 @@ data_buffer repository::create_commit(const signature &author,
   for (auto &p : parents) {
     parents_c.push_back(p.c_ptr());
   }
-  if (git_commit_create_buffer(&buf, c_ptr_, author.c_ptr(),
+  git_exception::throw_nonzero(
+      git_commit_create_buffer(&buf, c_ptr_, author.c_ptr(),
                                committer.c_ptr(), message_encoding_c,
                                message.c_str(), tree.c_ptr(), parents.size(),
-                               parents_c.data()))
-    throw git_exception();
+                               parents_c.data()));
   return data_buffer(&buf);
 }
 
@@ -819,10 +791,10 @@ oid repository::create_commit(const std::string &commit_content,
   const char *signature_c = signature == "" ? NULL : signature.c_str();
   const char *signature_field_c =
       signature_field == "" ? "" : signature_field.c_str();
-  if (git_commit_create_with_signature(result.c_ptr(), c_ptr_,
+  git_exception::throw_nonzero(
+      git_commit_create_with_signature(result.c_ptr(), c_ptr_,
                                        commit_content.c_str(), signature_c,
-                                       signature_field_c))
-    throw git_exception();
+                                       signature_field_c));
   return result;
 }
 
@@ -830,23 +802,23 @@ std::pair<data_buffer, data_buffer>
 repository::extract_signature_from_commit(oid id,
                                           const std::string &signature_field) const {
   git_buf sig, signed_data;
-  if (git_commit_extract_signature(&sig, &signed_data, c_ptr_,
-                                   id.c_ptr(), signature_field.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_commit_extract_signature(&sig, &signed_data, c_ptr_,
+                                   id.c_ptr(), signature_field.c_str()));
   return std::pair<data_buffer, data_buffer>{std::move(data_buffer(&sig)), std::move(data_buffer(&signed_data))};
 }
 
 commit repository::lookup_commit(const oid &id) const {
   commit result(nullptr, ownership::user);
-  if (git_commit_lookup(&result.c_ptr_, c_ptr_, id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_commit_lookup(&result.c_ptr_, c_ptr_, id.c_ptr()));
   return result;
 }
 
 commit repository::lookup_commit(const oid &id, size_t length) const {
   commit result(nullptr, ownership::user);
-  if (git_commit_lookup_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), length))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_commit_lookup_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), length));
   return result;
 }
 
@@ -858,7 +830,7 @@ void repository::for_each_commit(std::function<void(const commit &id)> visitor,
 
   if (ret != 0) {
     git_revwalk_free(iter);
-    throw git_exception();
+    throw git_exception(ret);
   }
 
   git_revwalk_sorting(iter, static_cast<unsigned int>(sort_ordering));
@@ -879,7 +851,7 @@ void repository::for_each_commit(std::function<void(const commit &id)> visitor,
 
   if (ret != 0) {
     git_revwalk_free(iter);
-    throw git_exception();
+    throw git_exception(ret);
   }
 
   git_revwalk_sorting(iter, static_cast<unsigned int>(sort_ordering));
@@ -895,20 +867,20 @@ void repository::add_ondisk_config_file(const cppgit2::config &cfg,
                                         const std::string &path,
                                         config::priority_level level,
                                         bool force) const {
-  if (git_config_add_file_ondisk(cfg.c_ptr_, path.c_str(),
+  git_exception::throw_nonzero(
+      git_config_add_file_ondisk(cfg.c_ptr_, path.c_str(),
                                  static_cast<git_config_level_t>(level), c_ptr_,
-                                 force))
-    throw git_exception();
+                                 force));
 }
 
 data_buffer repository::create_diff_commit_as_email(
     const commit &commit, size_t patch_no, size_t total_patches,
     diff::format_email_flag flags, const diff::options &options) const {
   git_buf buf = GIT_BUF_INIT;
-  if (git_diff_commit_as_email(&buf, c_ptr_, commit.c_ptr_, patch_no,
+  git_exception::throw_nonzero(
+      git_diff_commit_as_email(&buf, c_ptr_, commit.c_ptr_, patch_no,
                                total_patches, static_cast<uint32_t>(flags),
-                               options.c_ptr()))
-    throw git_exception();
+                               options.c_ptr()));
   return data_buffer(&buf);
 }
 
@@ -916,18 +888,18 @@ diff repository::create_diff_index_to_index(const cppgit2::index &old_index,
                                             const cppgit2::index &new_index,
                                             const diff::options &options) const {
   diff result(nullptr, ownership::user);
-  if (git_diff_index_to_index(&result.c_ptr_, c_ptr_, old_index.c_ptr_,
-                              new_index.c_ptr_, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_index_to_index(&result.c_ptr_, c_ptr_, old_index.c_ptr_,
+                              new_index.c_ptr_, options.c_ptr()));
   return result;
 }
 
 diff repository::create_diff_index_to_workdir(const cppgit2::index &index,
                                               const diff::options &options) const {
   diff result(nullptr, ownership::user);
-  if (git_diff_index_to_workdir(&result.c_ptr_, c_ptr_, index.c_ptr_,
-                                options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_index_to_workdir(&result.c_ptr_, c_ptr_, index.c_ptr_,
+                                options.c_ptr()));
   return result;
 }
 
@@ -935,9 +907,9 @@ diff repository::create_diff_tree_to_index(const tree &old_tree,
                                            const cppgit2::index &index,
                                            const diff::options &options) const {
   diff result(nullptr, ownership::user);
-  if (git_diff_tree_to_index(&result.c_ptr_, c_ptr_, old_tree.c_ptr_,
-                             index.c_ptr_, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_tree_to_index(&result.c_ptr_, c_ptr_, old_tree.c_ptr_,
+                             index.c_ptr_, options.c_ptr()));
   return result;
 }
 
@@ -945,27 +917,27 @@ diff repository::create_diff_tree_to_tree(const tree &old_tree,
                                           const tree &new_tree,
                                           const diff::options &options) const {
   diff result(nullptr, ownership::user);
-  if (git_diff_tree_to_tree(&result.c_ptr_, c_ptr_, old_tree.c_ptr_,
-                            new_tree.c_ptr_, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_tree_to_tree(&result.c_ptr_, c_ptr_, old_tree.c_ptr_,
+                            new_tree.c_ptr_, options.c_ptr()));
   return result;
 }
 
 diff repository::create_diff_tree_to_workdir(const tree &old_tree,
                                              const diff::options &options) const {
   diff result(nullptr, ownership::user);
-  if (git_diff_tree_to_workdir(&result.c_ptr_, c_ptr_, old_tree.c_ptr_,
-                               options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_tree_to_workdir(&result.c_ptr_, c_ptr_, old_tree.c_ptr_,
+                               options.c_ptr()));
   return result;
 }
 
 diff repository::create_diff_tree_to_workdir_with_index(
     const tree &old_tree, const diff::options &options) const {
   diff result(nullptr, ownership::user);
-  if (git_diff_tree_to_workdir_with_index(&result.c_ptr_, c_ptr_,
-                                          old_tree.c_ptr_, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_diff_tree_to_workdir_with_index(&result.c_ptr_, c_ptr_,
+                                          old_tree.c_ptr_, options.c_ptr()));
   return result;
 }
 
@@ -973,9 +945,9 @@ std::pair<size_t, size_t>
 repository::unique_commits_ahead_behind(const oid &local,
                                         const oid &upstream) const {
   size_t ahead, behind;
-  if (git_graph_ahead_behind(&ahead, &behind, c_ptr_, local.c_ptr(),
-                             upstream.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_graph_ahead_behind(&ahead, &behind, c_ptr_, local.c_ptr(),
+                             upstream.c_ptr()));
   return std::pair<size_t, size_t>{ahead, behind};
 }
 
@@ -985,19 +957,19 @@ bool repository::is_descendant_of(const oid &commit,
 }
 
 void repository::add_ignore_rules(const std::string &rules) const {
-  if (git_ignore_add_rule(c_ptr_, rules.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_ignore_add_rule(c_ptr_, rules.c_str()));
 }
 
 void repository::clear_ignore_rules() const {
-  if (git_ignore_clear_internal_rules(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_ignore_clear_internal_rules(c_ptr_));
 }
 
 bool repository::is_path_ignored(const std::string &path) const {
   int result;
-  if (git_ignore_path_is_ignored(&result, c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_ignore_path_is_ignored(&result, c_ptr_, path.c_str()));
   return result;
 }
 
@@ -1012,10 +984,10 @@ repository::analyze_merge(const std::vector<annotated_commit> &their_heads) cons
     their_heads_c.push_back(&their_heads[i].c_ptr_);
   }
 
-  if (git_merge_analysis(&analysis_result, &preference, c_ptr_,
+  git_exception::throw_nonzero(
+      git_merge_analysis(&analysis_result, &preference, c_ptr_,
                          (const git_annotated_commit **)their_heads_c.data(),
-                         num_commits))
-    throw git_exception();
+                         num_commits));
 
   return std::pair<merge::analysis_result, merge::preference>{
       static_cast<merge::analysis_result>(analysis_result),
@@ -1034,11 +1006,11 @@ repository::analyze_merge(const reference &our_ref,
     their_heads_c.push_back(&their_heads[i].c_ptr_);
   }
 
-  if (git_merge_analysis_for_ref(
+  git_exception::throw_nonzero(
+      git_merge_analysis_for_ref(
           &analysis_result, &preference, c_ptr_, our_ref.c_ptr_,
           (const git_annotated_commit **)their_heads_c.data(),
-          their_heads.size()))
-    throw git_exception();
+          their_heads.size()));
 
   return std::pair<merge::analysis_result, merge::preference>{
       static_cast<merge::analysis_result>(analysis_result),
@@ -1048,9 +1020,9 @@ repository::analyze_merge(const reference &our_ref,
 oid repository::find_merge_base(const oid &first_commit,
                                 const oid &second_commit) const {
   oid result;
-  if (git_merge_base(result.c_ptr(), c_ptr_, first_commit.c_ptr(),
-                     second_commit.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_merge_base(result.c_ptr(), c_ptr_, first_commit.c_ptr(),
+                     second_commit.c_ptr()));
   return result;
 }
 
@@ -1061,9 +1033,9 @@ oid repository::find_merge_base(const std::vector<oid> &commits) const {
   for (auto &c : commits)
     commits_c.push_back(c.c_struct_);
 
-  if (git_merge_base_many(result.c_ptr(), c_ptr_, commits.size(),
-                          commits_c.data()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_merge_base_many(result.c_ptr(), c_ptr_, commits.size(),
+                          commits_c.data()));
 
   return result;
 }
@@ -1076,9 +1048,9 @@ oid repository::find_merge_base_for_octopus_merge(
   for (auto &c : commits)
     commits_c.push_back(c.c_struct_);
 
-  if (git_merge_base_octopus(result.c_ptr(), c_ptr_, commits.size(),
-                             commits_c.data()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_merge_base_octopus(result.c_ptr(), c_ptr_, commits.size(),
+                             commits_c.data()));
 
   return result;
 }
@@ -1087,9 +1059,9 @@ std::vector<oid> repository::find_merge_bases(const oid &first_commit,
                                               const oid &second_commit) const {
   std::vector<oid> result{};
   git_oidarray result_c;
-  if (git_merge_bases(&result_c, c_ptr_, first_commit.c_ptr(),
-                      second_commit.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_merge_bases(&result_c, c_ptr_, first_commit.c_ptr(),
+                      second_commit.c_ptr()));
 
   for (size_t i = 0; i < result_c.count; ++i) {
     result.push_back(oid(&result_c.ids[i]));
@@ -1105,8 +1077,8 @@ std::vector<oid> repository::find_merge_bases(const std::vector<oid> &commits) c
   for (auto &c : commits)
     commits_c.push_back(c.c_struct_);
 
-  if (git_merge_bases_many(&result_c, c_ptr_, commits.size(), commits_c.data()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_merge_bases_many(&result_c, c_ptr_, commits.size(), commits_c.data()));
 
   for (size_t i = 0; i < result_c.count; ++i) {
     result.push_back(oid(&result_c.ids[i]));
@@ -1123,19 +1095,19 @@ void repository::merge_commits(const std::vector<annotated_commit> &their_heads,
     their_heads_c.push_back(&their_heads[i].c_ptr_);
   }
 
-  if (git_merge(c_ptr_, (const git_annotated_commit **)their_heads_c.data(),
+  git_exception::throw_nonzero(
+      git_merge(c_ptr_, (const git_annotated_commit **)their_heads_c.data(),
                 their_heads.size(), merge_options.c_ptr(),
-                checkout_options.c_ptr()))
-    throw git_exception();
+                checkout_options.c_ptr()));
 }
 
 cppgit2::index repository::merge_commits(const commit &our_commit,
                                          const commit &their_commit,
                                          const merge::options &merge_options) const {
   cppgit2::index result(nullptr, ownership::user);
-  if (git_merge_commits(&result.c_ptr_, c_ptr_, our_commit.c_ptr_,
-                        their_commit.c_ptr_, merge_options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_merge_commits(&result.c_ptr_, c_ptr_, our_commit.c_ptr_,
+                        their_commit.c_ptr_, merge_options.c_ptr()));
   return result;
 }
 
@@ -1143,9 +1115,9 @@ merge::file::result repository::merge_file_from_index(
     const index::entry &ancestor, const index::entry &ours,
     const index::entry &theirs, const merge::file::options &options) const {
   git_merge_file_result result;
-  if (git_merge_file_from_index(&result, c_ptr_, ancestor.c_ptr(), ours.c_ptr(),
-                                theirs.c_ptr(), options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_merge_file_from_index(&result, c_ptr_, ancestor.c_ptr(), ours.c_ptr(),
+                                theirs.c_ptr(), options.c_ptr()));
   return merge::file::result(&result);
 }
 
@@ -1154,9 +1126,9 @@ cppgit2::index repository::merge_trees(const tree &ancestor_tree,
                                        const tree &their_tree,
                                        const merge::options &options) const {
   cppgit2::index result(nullptr, ownership::user);
-  if (git_merge_trees(&result.c_ptr_, c_ptr_, ancestor_tree.c_ptr_,
-                      our_tree.c_ptr_, their_tree.c_ptr_, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_merge_trees(&result.c_ptr_, c_ptr_, ancestor_tree.c_ptr_,
+                      our_tree.c_ptr_, their_tree.c_ptr_, options.c_ptr()));
   return result;
 }
 
@@ -1165,9 +1137,9 @@ oid repository::create_note(const std::string &notes_ref,
                             const oid &id, const std::string &note,
                             bool force) const {
   oid result;
-  if (git_note_create(result.c_ptr(), c_ptr_, notes_ref.c_str(), author.c_ptr(),
-                      committer.c_ptr(), id.c_ptr(), note.c_str(), force))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_note_create(result.c_ptr(), c_ptr_, notes_ref.c_str(), author.c_ptr(),
+                      committer.c_ptr(), id.c_ptr(), note.c_str(), force));
   return result;
 }
 
@@ -1176,50 +1148,50 @@ repository::create_note(const commit &parent, const signature &author,
                         const signature &committer, const oid &id,
                         const std::string &note, bool allow_note_override) const {
   oid notes_commit_out, notes_blob_out;
-  if (git_note_commit_create(notes_commit_out.c_ptr(), notes_blob_out.c_ptr(),
+  git_exception::throw_nonzero(
+      git_note_commit_create(notes_commit_out.c_ptr(), notes_blob_out.c_ptr(),
                              c_ptr_, parent.c_ptr_, author.c_ptr(),
                              committer.c_ptr(), id.c_ptr(), note.c_str(),
-                             allow_note_override))
-    throw git_exception();
+                             allow_note_override));
   return std::pair<oid, oid>{notes_commit_out, notes_blob_out};
 }
 
 note repository::read_note(const std::string &notes_ref, const oid &id) const {
   note result(nullptr, ownership::user);
-  if (git_note_read(&result.c_ptr_, c_ptr_, notes_ref.c_str(), id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_note_read(&result.c_ptr_, c_ptr_, notes_ref.c_str(), id.c_ptr()));
   return result;
 }
 
 note repository::read_note(const commit &notes_commit, const oid &id) const {
   note result(nullptr, ownership::user);
-  if (git_note_commit_read(&result.c_ptr_, c_ptr_, notes_commit.c_ptr_,
-                           id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_note_commit_read(&result.c_ptr_, c_ptr_, notes_commit.c_ptr_,
+                           id.c_ptr()));
   return result;
 }
 
 void repository::remove_note(const std::string &notes_ref,
                              const signature &author,
                              const signature &committer, const oid &id) const {
-  if (git_note_remove(c_ptr_, notes_ref.c_str(), author.c_ptr(),
-                      committer.c_ptr(), id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_note_remove(c_ptr_, notes_ref.c_str(), author.c_ptr(),
+                      committer.c_ptr(), id.c_ptr()));
 }
 
 oid repository::remove_note(const commit &notes_commit, const signature &author,
                             const signature &committer, const oid &id) const {
   oid result;
-  if (git_note_commit_remove(result.c_ptr(), c_ptr_, notes_commit.c_ptr_,
-                             author.c_ptr(), committer.c_ptr(), id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_note_commit_remove(result.c_ptr(), c_ptr_, notes_commit.c_ptr_,
+                             author.c_ptr(), committer.c_ptr(), id.c_ptr()));
   return result;
 }
 
 data_buffer repository::detault_notes_reference() const {
   git_buf buf = GIT_BUF_INIT;
-  if (git_note_default_ref(&buf, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_note_default_ref(&buf, c_ptr_));
   return data_buffer(&buf);
 }
 
@@ -1240,42 +1212,42 @@ void repository::for_each_note(
     return 0;
   };
 
-  if (git_note_foreach(c_ptr_, notes_ref.c_str(), callback_c,
-                       (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_note_foreach(c_ptr_, notes_ref.c_str(), callback_c,
+                       (void *)(&wrapper)));
 }
 
 object repository::lookup_object(const oid &id,
                                  object::object_type type) const {
   object result(nullptr, ownership::user);
-  if (git_object_lookup(&result.c_ptr_, c_ptr_, id.c_ptr(),
-                        static_cast<git_object_t>(type)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_object_lookup(&result.c_ptr_, c_ptr_, id.c_ptr(),
+                      static_cast<git_object_t>(type)));
   return result;
 }
 
 object repository::lookup_object(const oid &id, size_t length,
                                  object::object_type type) const {
   object result(nullptr, ownership::user);
-  if (git_object_lookup_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), length,
-                               static_cast<git_object_t>(type)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_object_lookup_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), length,
+                               static_cast<git_object_t>(type)));
   return result;
 }
 
 object repository::lookup_object(const object &treeish, const std::string &path,
                                  object::object_type type) const {
   object result(nullptr, ownership::user);
-  if (git_object_lookup_bypath(&result.c_ptr_, treeish.c_ptr_, path.c_str(),
-                               static_cast<git_object_t>(type)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_object_lookup_bypath(&result.c_ptr_, treeish.c_ptr_, path.c_str(),
+                               static_cast<git_object_t>(type)));
   return result;
 }
 
 pack_builder repository::initialize_pack_builder() const {
   pack_builder result(nullptr, ownership::user);
-  if (git_packbuilder_new(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_packbuilder_new(&result.c_ptr_, c_ptr_));
   return result;
 }
 
@@ -1284,30 +1256,30 @@ rebase repository::init_rebase(const annotated_commit &branch,
                                const annotated_commit &onto,
                                const rebase::options &options) const {
   rebase result(nullptr, ownership::user);
-  if (git_rebase_init(&result.c_ptr_, c_ptr_, branch.c_ptr(), upstream.c_ptr(),
-                      onto.c_ptr(), options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_rebase_init(&result.c_ptr_, c_ptr_, branch.c_ptr(), upstream.c_ptr(),
+                      onto.c_ptr(), options.c_ptr()));
   return result;
 }
 
 rebase repository::open_rebase(const rebase::options &options) const {
   rebase result(nullptr, ownership::user);
-  if (git_rebase_open(&result.c_ptr_, c_ptr_, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_rebase_open(&result.c_ptr_, c_ptr_, options.c_ptr()));
   return result;
 }
 
 cppgit2::refdb repository::create_refdb() const {
   cppgit2::refdb result(nullptr, ownership::user);
-  if (git_refdb_new(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_refdb_new(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 cppgit2::refdb repository::open_refdb() const {
   cppgit2::refdb result(nullptr, ownership::user);
-  if (git_refdb_open(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_refdb_open(&result.c_ptr_, c_ptr_));
   return result;
 }
 
@@ -1315,9 +1287,9 @@ reference repository::create_reference(const std::string &name, const oid &id,
                                        bool force,
                                        const std::string &log_message) const {
   reference result(nullptr, ownership::user);
-  if (git_reference_create(&result.c_ptr_, c_ptr_, name.c_str(), id.c_ptr(),
-                           force, log_message.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reference_create(&result.c_ptr_, c_ptr_, name.c_str(), id.c_ptr(),
+                           force, log_message.c_str()));
   return result;
 }
 
@@ -1325,29 +1297,29 @@ reference repository::create_reference(const std::string &name, const oid &id,
                                        bool force, const oid &current_id,
                                        const std::string &log_message) const {
   reference result(nullptr, ownership::user);
-  if (git_reference_create_matching(&result.c_ptr_, c_ptr_, name.c_str(),
+  git_exception::throw_nonzero(
+      git_reference_create_matching(&result.c_ptr_, c_ptr_, name.c_str(),
                                     id.c_ptr(), force, current_id.c_ptr(),
-                                    log_message.c_str()))
-    throw git_exception();
+                                    log_message.c_str()));
   return result;
 }
 
 void repository::delete_reference(const std::string &refname) const {
-  if (git_reference_remove(c_ptr_, refname.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reference_remove(c_ptr_, refname.c_str()));
 }
 
 reference
 repository::lookup_reference_by_dwim(const std::string &shorthand_name) const {
   reference result(nullptr, ownership::user);
-  if (git_reference_dwim(&result.c_ptr_, c_ptr_, shorthand_name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reference_dwim(&result.c_ptr_, c_ptr_, shorthand_name.c_str()));
   return result;
 }
 
 void repository::ensure_reflog_for_reference(const std::string &refname) const {
-  if (git_reference_ensure_log(c_ptr_, refname.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reference_ensure_log(c_ptr_, refname.c_str()));
 }
 
 bool repository::reference_has_reflog(const std::string &refname) const {
@@ -1356,22 +1328,22 @@ bool repository::reference_has_reflog(const std::string &refname) const {
 
 strarray repository::reference_list() const {
   strarray result;
-  if (git_reference_list(&result.c_struct_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reference_list(&result.c_struct_, c_ptr_));
   return result;
 }
 
 reference repository::lookup_reference(const std::string &refname) const {
   reference result(nullptr, ownership::user);
-  if (git_reference_lookup(&result.c_ptr_, c_ptr_, refname.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reference_lookup(&result.c_ptr_, c_ptr_, refname.c_str()));
   return result;
 }
 
 oid repository::reference_name_to_id(const std::string &refname) const {
   oid result;
-  if (git_reference_name_to_id(result.c_ptr(), c_ptr_, refname.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reference_name_to_id(result.c_ptr(), c_ptr_, refname.c_str()));
   return result;
 }
 
@@ -1380,9 +1352,9 @@ repository::create_symbolic_reference(const std::string &name,
                                       const std::string &target, bool force,
                                       const std::string &log_message) const {
   reference result(nullptr, ownership::user);
-  if (git_reference_symbolic_create(&result.c_ptr_, c_ptr_, name.c_str(),
-                                    target.c_str(), force, log_message.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reference_symbolic_create(&result.c_ptr_, c_ptr_, name.c_str(),
+                                    target.c_str(), force, log_message.c_str()));
   return result;
 }
 
@@ -1390,10 +1362,10 @@ reference repository::create_symbolic_reference(
     const std::string &name, const std::string &target, bool force,
     const std::string &current_value, const std::string &log_message) const {
   reference result(nullptr, ownership::user);
-  if (git_reference_symbolic_create_matching(
+  git_exception::throw_nonzero(
+      git_reference_symbolic_create_matching(
           &result.c_ptr_, c_ptr_, name.c_str(), target.c_str(), force,
-          current_value.c_str(), log_message.c_str()))
-    throw git_exception();
+          current_value.c_str(), log_message.c_str()));
   return result;
 }
 
@@ -1441,69 +1413,69 @@ void repository::for_each_reference_glob(
 }
 
 void repository::delete_reflog(const std::string &name) const {
-  if (git_reflog_delete(c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reflog_delete(c_ptr_, name.c_str()));
 }
 
 reflog repository::read_reflog(const std::string &name) const {
   reflog result(nullptr, ownership::user);
-  if (git_reflog_read(&result.c_ptr_, c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reflog_read(&result.c_ptr_, c_ptr_, name.c_str()));
   return result;
 }
 
 void repository::rename_reflog(const std::string &old_name,
                                const std::string &name) const {
-  if (git_reflog_rename(c_ptr_, old_name.c_str(), name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reflog_rename(c_ptr_, old_name.c_str(), name.c_str()));
 }
 
 void repository::reset(const object &target, reset::reset_type reset_type,
                        const checkout::options &options) const {
-  if (git_reset(c_ptr_, target.c_ptr(), static_cast<git_reset_t>(reset_type),
-                options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reset(c_ptr_, target.c_ptr(), static_cast<git_reset_t>(reset_type),
+                options.c_ptr()));
 }
 
 void repository::reset_default(const object &target,
                                const std::vector<std::string> &pathspecs) const {
-  if (git_reset_default(c_ptr_, target.c_ptr(), strarray(pathspecs).c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_reset_default(c_ptr_, target.c_ptr(), strarray(pathspecs).c_ptr()));
 }
 
 void repository::reset(const annotated_commit &target,
                        reset::reset_type reset_type,
                        const checkout::options &options) const {
-  if (git_reset_from_annotated(c_ptr_, target.c_ptr(),
+  git_exception::throw_nonzero(
+      git_reset_from_annotated(c_ptr_, target.c_ptr(),
                                static_cast<git_reset_t>(reset_type),
-                               options.c_ptr()))
-    throw git_exception();
+                               options.c_ptr()));
 }
 
 void repository::add_fetch_refspec_to_remote(const std::string &remote,
                                              const std::string &refspec) const {
-  if (git_remote_add_fetch(c_ptr_, remote.c_str(), refspec.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_add_fetch(c_ptr_, remote.c_str(), refspec.c_str()));
 }
 
 void repository::add_push_refspec_to_remote(const std::string &remote,
                                             const std::string &refspec) const {
-  if (git_remote_add_push(c_ptr_, remote.c_str(), refspec.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_add_push(c_ptr_, remote.c_str(), refspec.c_str()));
 }
 
 remote repository::create_remote(const std::string &name,
                                  const std::string &url) const {
   remote result(nullptr, ownership::user);
-  if (git_remote_create(&result.c_ptr_, c_ptr_, name.c_str(), url.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_create(&result.c_ptr_, c_ptr_, name.c_str(), url.c_str()));
   return result;
 }
 
 remote repository::create_anonymous_remote(const std::string &url) const {
   remote result(nullptr, ownership::user);
-  if (git_remote_create_anonymous(&result.c_ptr_, c_ptr_, url.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_create_anonymous(&result.c_ptr_, c_ptr_, url.c_str()));
   return result;
 }
 
@@ -1511,63 +1483,63 @@ remote repository::create_remote(const std::string &name,
                                  const std::string &url,
                                  const std::string &fetch_refspec) const {
   remote result(nullptr, ownership::user);
-  if (git_remote_create_with_fetchspec(&result.c_ptr_, c_ptr_, name.c_str(),
-                                       url.c_str(), fetch_refspec.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_create_with_fetchspec(&result.c_ptr_, c_ptr_, name.c_str(),
+                                       url.c_str(), fetch_refspec.c_str()));
   return result;
 }
 
 void repository::delete_remote(const std::string &name) const {
-  if (git_remote_delete(c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_delete(c_ptr_, name.c_str()));
 }
 
 strarray repository::remote_list() const {
   strarray result;
-  if (git_remote_list(&result.c_struct_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_list(&result.c_struct_, c_ptr_));
   return result;
 }
 
 remote repository::lookup_remote(const std::string &name) const {
   remote result(nullptr, ownership::user);
-  if (git_remote_lookup(&result.c_ptr_, c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_lookup(&result.c_ptr_, c_ptr_, name.c_str()));
   return result;
 }
 
 strarray repository::rename_remote(const std::string &name,
                                    const std::string &new_name) const {
   strarray result;
-  if (git_remote_rename(&result.c_struct_, c_ptr_, name.c_str(),
-                        new_name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_rename(&result.c_struct_, c_ptr_, name.c_str(),
+                        new_name.c_str()));
   return result;
 }
 
 void repository::set_remote_autotag(const std::string &remote,
                                     fetch::options::autotag option) const {
-  if (git_remote_set_autotag(c_ptr_, remote.c_str(),
-                             static_cast<git_remote_autotag_option_t>(option)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_set_autotag(c_ptr_, remote.c_str(),
+                             static_cast<git_remote_autotag_option_t>(option)));
 }
 
 void repository::set_remote_push_url(const std::string &remote,
                                      const std::string &url) const {
-  if (git_remote_set_pushurl(c_ptr_, remote.c_str(), url.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_set_pushurl(c_ptr_, remote.c_str(), url.c_str()));
 }
 
 void repository::set_remote_url(const std::string &remote,
                                 const std::string &url) const {
-  if (git_remote_set_url(c_ptr_, remote.c_str(), url.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_remote_set_url(c_ptr_, remote.c_str(), url.c_str()));
 }
 
 void repository::revert_commit(const commit &commit,
                                const revert::options &options) const {
-  if (git_revert(c_ptr_, commit.c_ptr_, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_revert(c_ptr_, commit.c_ptr_, options.c_ptr()));
 }
 
 cppgit2::index repository::revert_commit(const commit &revert_commit,
@@ -1575,16 +1547,16 @@ cppgit2::index repository::revert_commit(const commit &revert_commit,
                                          unsigned int mainline,
                                          const merge::options &options) const {
   cppgit2::index result(nullptr, ownership::user);
-  if (git_revert_commit(&result.c_ptr_, c_ptr_, revert_commit.c_ptr_,
-                        our_commit.c_ptr_, mainline, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_revert_commit(&result.c_ptr_, c_ptr_, revert_commit.c_ptr_,
+                        our_commit.c_ptr_, mainline, options.c_ptr()));
   return result;
 }
 
 revspec repository::revparse(const std::string &spec) const {
   revspec result;
-  if (git_revparse(result.c_ptr_, c_ptr_, spec.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_revparse(result.c_ptr_, c_ptr_, spec.c_str()));
   result.from_ = object(result.c_ptr_->from, ownership::user);
   result.to_ = object(result.c_ptr_->to, ownership::user);
   return result;
@@ -1594,42 +1566,42 @@ std::pair<object, reference>
 repository::revparse_to_object_and_reference(const std::string &spec) const {
   object object_out(nullptr, ownership::user);
   reference reference_out(nullptr, ownership::user);
-  if (git_revparse_ext(&object_out.c_ptr_, &reference_out.c_ptr_, c_ptr_,
-                       spec.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_revparse_ext(&object_out.c_ptr_, &reference_out.c_ptr_, c_ptr_,
+                       spec.c_str()));
   return std::pair<object, reference>{object_out, reference_out};
 }
 
 object repository::revparse_to_object(const std::string &spec) const {
   object result(nullptr, ownership::user);
-  if (git_revparse_single(&result.c_ptr_, c_ptr_, spec.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_revparse_single(&result.c_ptr_, c_ptr_, spec.c_str()));
   return result;
 }
 
 revwalk repository::create_revwalk() const {
   revwalk result(nullptr, ownership::user);
-  if (git_revwalk_new(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_revwalk_new(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 signature repository::default_signature() const {
   signature result;
-  if (git_signature_default(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_signature_default(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 void repository::apply_stash(size_t index,
                              const stash::apply::options &options) const {
-  if (git_stash_apply(c_ptr_, index, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_stash_apply(c_ptr_, index, options.c_ptr()));
 }
 
 void repository::drop_stash(size_t index) const {
-  if (git_stash_drop(c_ptr_, index))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_stash_drop(c_ptr_, index));
 }
 
 void repository::for_each_stash(
@@ -1649,28 +1621,28 @@ void repository::for_each_stash(
     return 0;
   };
 
-  if (git_stash_foreach(c_ptr_, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_stash_foreach(c_ptr_, callback_c, (void *)(&wrapper)));
 }
 
 void repository::pop_stash(size_t index, const stash::apply::options &options) const {
-  if (git_stash_pop(c_ptr_, index, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_stash_pop(c_ptr_, index, options.c_ptr()));
 }
 
 oid repository::save_stash(const signature &stasher, const std::string &message,
                            stash::apply::flag flags) const {
   oid result;
-  if (git_stash_save(result.c_ptr(), c_ptr_, stasher.c_ptr(), message.c_str(),
-                     static_cast<uint32_t>(flags)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_stash_save(result.c_ptr(), c_ptr_, stasher.c_ptr(), message.c_str(),
+                     static_cast<uint32_t>(flags)));
   return result;
 }
 
 status::status_type repository::status_file(const std::string &path) const {
   unsigned int result;
-  if (git_status_file(&result, c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_status_file(&result, c_ptr_, path.c_str()));
   return static_cast<status::status_type>(result);
 }
 
@@ -1690,8 +1662,8 @@ void repository::for_each_status(
     return 0;
   };
 
-  if (git_status_foreach(c_ptr_, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_status_foreach(c_ptr_, callback_c, (void *)(&wrapper)));
 }
 
 void repository::for_each_status(
@@ -1711,22 +1683,22 @@ void repository::for_each_status(
     return 0;
   };
 
-  if (git_status_foreach_ext(c_ptr_, options.c_ptr(), callback_c,
-                             (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_status_foreach_ext(c_ptr_, options.c_ptr(), callback_c,
+                           (void *)(&wrapper)));
 }
 
 status::list repository::status_list(const status::options &options) const {
   status::list result(nullptr, ownership::user);
-  if (git_status_list_new(&result.c_ptr_, c_ptr_, options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_status_list_new(&result.c_ptr_, c_ptr_, options.c_ptr()));
   return result;
 }
 
 bool repository::should_ignore(const std::string &path) const {
   int result;
-  if (git_status_should_ignore(&result, c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_status_should_ignore(&result, c_ptr_, path.c_str()));
   return result;
 }
 
@@ -1734,9 +1706,9 @@ submodule repository::setup_submodule(const std::string &url,
                                       const std::string &path,
                                       bool use_gitlink) const {
   submodule result(nullptr, ownership::user);
-  if (git_submodule_add_setup(&result.c_ptr_, c_ptr_, url.c_str(), path.c_str(),
-                              use_gitlink))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_submodule_add_setup(&result.c_ptr_, c_ptr_, url.c_str(), path.c_str(),
+                              use_gitlink));
   return result;
 }
 
@@ -1762,67 +1734,67 @@ void repository::for_each_submodule(
     return 0;
   };
 
-  if (git_submodule_foreach(c_ptr_, visitor_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_submodule_foreach(c_ptr_, visitor_c, (void *)(&wrapper)));
 }
 
 submodule repository::lookup_submodule(const std::string &name) const {
   submodule result(nullptr, ownership::user);
-  if (git_submodule_lookup(&result.c_ptr_, c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_submodule_lookup(&result.c_ptr_, c_ptr_, name.c_str()));
   return result;
 }
 
 data_buffer repository::resolve_submodule_url(const std::string &url) const {
   git_buf buf = GIT_BUF_INIT;
-  if (git_submodule_resolve_url(&buf, c_ptr_, url.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_submodule_resolve_url(&buf, c_ptr_, url.c_str()));
   return data_buffer(&buf);
 }
 
 void repository::set_submodule_branch(const std::string &submodule_name,
                                       const std::string &branch_name) const {
-  if (git_submodule_set_branch(c_ptr_, submodule_name.c_str(),
-                               branch_name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_submodule_set_branch(c_ptr_, submodule_name.c_str(),
+                             branch_name.c_str()));
 }
 
 void repository::set_submodule_fetch_recurse_option(
     const std::string &submodule_name,
     submodule::recurse fetch_recurse_submodules) const {
-  if (git_submodule_set_fetch_recurse_submodules(
+  git_exception::throw_nonzero(
+      git_submodule_set_fetch_recurse_submodules(
           c_ptr_, submodule_name.c_str(),
-          static_cast<git_submodule_recurse_t>(fetch_recurse_submodules)))
-    throw git_exception();
+          static_cast<git_submodule_recurse_t>(fetch_recurse_submodules)));
 }
 
 void repository::set_submodule_ignore_option(const std::string &submodule_name,
                                              submodule::ignore ignore) const {
-  if (git_submodule_set_ignore(c_ptr_, submodule_name.c_str(),
-                               static_cast<git_submodule_ignore_t>(ignore)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_submodule_set_ignore(c_ptr_, submodule_name.c_str(),
+                               static_cast<git_submodule_ignore_t>(ignore)));
 }
 
 void repository::set_submodule_update_option(
     const std::string &submodule_name, submodule::update_strategy update) const {
-  if (git_submodule_set_update(c_ptr_, submodule_name.c_str(),
-                               static_cast<git_submodule_update_t>(update)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_submodule_set_update(c_ptr_, submodule_name.c_str(),
+                               static_cast<git_submodule_update_t>(update)));
 }
 
 void repository::set_submodule_url(const std::string &submodule_name,
                                    const std::string &submodule_url) const {
-  if (git_submodule_set_url(c_ptr_, submodule_name.c_str(),
-                            submodule_url.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_submodule_set_url(c_ptr_, submodule_name.c_str(),
+                            submodule_url.c_str()));
 }
 
 submodule::status repository::submodule_status(const std::string &name,
                                                submodule::ignore ignore) const {
   unsigned int result;
-  if (git_submodule_status(&result, c_ptr_, name.c_str(),
-                           static_cast<git_submodule_ignore_t>(ignore)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_submodule_status(&result, c_ptr_, name.c_str(),
+                           static_cast<git_submodule_ignore_t>(ignore)));
   return static_cast<submodule::status>(result);
 }
 
@@ -1831,10 +1803,10 @@ oid repository::create_tag_annotation(const std::string &tag_name,
                                       const signature &tagger,
                                       const std::string &message) const {
   oid result;
-  if (git_tag_annotation_create(result.c_ptr(), c_ptr_, tag_name.c_str(),
+  git_exception::throw_nonzero(
+      git_tag_annotation_create(result.c_ptr(), c_ptr_, tag_name.c_str(),
                                 target.c_ptr(), tagger.c_ptr(),
-                                message.c_str()))
-    throw git_exception();
+                                message.c_str()));
   return result;
 }
 
@@ -1842,31 +1814,31 @@ oid repository::create_tag(const std::string &tag_name, const object &target,
                            const signature &tagger, const std::string &message,
                            bool force) const {
   oid result;
-  if (git_tag_create(result.c_ptr(), c_ptr_, tag_name.c_str(), target.c_ptr(),
-                     tagger.c_ptr(), message.c_str(), force))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tag_create(result.c_ptr(), c_ptr_, tag_name.c_str(), target.c_ptr(),
+                     tagger.c_ptr(), message.c_str(), force));
   return result;
 }
 
 oid repository::create_tag(const std::string &buffer, bool force) const {
   oid result;
-  if (git_tag_create_frombuffer(result.c_ptr(), c_ptr_, buffer.c_str(), force))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tag_create_frombuffer(result.c_ptr(), c_ptr_, buffer.c_str(), force));
   return result;
 }
 
 oid repository::create_lightweight_tag(const std::string &tag_name,
                                        const object &target, bool force) const {
   oid result;
-  if (git_tag_create_lightweight(result.c_ptr(), c_ptr_, tag_name.c_str(),
-                                 target.c_ptr(), force))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tag_create_lightweight(result.c_ptr(), c_ptr_, tag_name.c_str(),
+                               target.c_ptr(), force));
   return result;
 }
 
 void repository::delete_tag(const std::string &tag_name) const {
-  if (git_tag_delete(c_ptr_, tag_name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tag_delete(c_ptr_, tag_name.c_str()));
 }
 
 void repository::for_each_tag(
@@ -1884,63 +1856,63 @@ void repository::for_each_tag(
     return 0;
   };
 
-  if (git_tag_foreach(c_ptr_, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tag_foreach(c_ptr_, callback_c, (void *)(&wrapper)));
 }
 
 strarray repository::tags() const {
   strarray result;
-  if (git_tag_list(&result.c_struct_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tag_list(&result.c_struct_, c_ptr_));
   return result;
 }
 
 strarray repository::tags_that_match(const std::string &pattern) const {
   strarray result;
-  if (git_tag_list_match(&result.c_struct_, pattern.c_str(), c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tag_list_match(&result.c_struct_, pattern.c_str(), c_ptr_));
   return result;
 }
 
 tag repository::lookup_tag(const oid &id) const {
   tag result(nullptr, ownership::user);
-  if (git_tag_lookup(&result.c_ptr_, c_ptr_, id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tag_lookup(&result.c_ptr_, c_ptr_, id.c_ptr()));
   return result;
 }
 
 tag repository::lookup_tag(const oid &id, size_t length) const {
   tag result(nullptr, ownership::user);
-  if (git_tag_lookup_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), length))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tag_lookup_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), length));
   return result;
 }
 
 transaction repository::create_transaction() const {
   transaction result(nullptr, ownership::user);
-  if (git_transaction_new(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_transaction_new(&result.c_ptr_, c_ptr_));
   return result;
 }
 
 object repository::tree_entry_to_object(const tree::entry &entry) const {
   object result(nullptr, ownership::user);
-  if (git_tree_entry_to_object(&result.c_ptr_, c_ptr_, entry.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tree_entry_to_object(&result.c_ptr_, c_ptr_, entry.c_ptr()));
   return result;
 }
 
 tree repository::lookup_tree(const oid &id) const {
   tree result(nullptr, ownership::user);
-  if (git_tree_lookup(&result.c_ptr_, c_ptr_, id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tree_lookup(&result.c_ptr_, c_ptr_, id.c_ptr()));
   return result;
 }
 
 tree repository::lookup_tree(const oid &id, size_t length) const {
   tree result(nullptr, ownership::user);
-  if (git_tree_lookup_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), length))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tree_lookup_prefix(&result.c_ptr_, c_ptr_, id.c_ptr(), length));
   return result;
 }
 
@@ -1952,9 +1924,9 @@ oid repository::create_updated_tree(const tree &baseline,
   for (size_t i = 0; i < updates.size(); ++i)
     updates_c[i] = updates[i].c_struct_;
 
-  if (git_tree_create_updated(result.c_ptr(), c_ptr_, baseline.c_ptr_,
-                              updates.size(), updates_c))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_tree_create_updated(result.c_ptr(), c_ptr_, baseline.c_ptr_,
+                            updates.size(), updates_c));
   free(updates_c);
   return result;
 }
@@ -1963,30 +1935,30 @@ worktree repository::add_worktree(const std::string &name,
                                   const std::string &path,
                                   const worktree::add_options &options) const {
   worktree result(nullptr, ownership::user);
-  if (git_worktree_add(&result.c_ptr_, c_ptr_, name.c_str(), path.c_str(),
-                       options.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_worktree_add(&result.c_ptr_, c_ptr_, name.c_str(), path.c_str(),
+                       options.c_ptr()));
   return result;
 }
 
 strarray repository::list_worktrees() const {
   strarray result;
-  if (git_worktree_list(&result.c_struct_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_worktree_list(&result.c_struct_, c_ptr_));
   return result;
 }
 
 worktree repository::lookup_worktree(const std::string &name) const {
   worktree result(nullptr, ownership::user);
-  if (git_worktree_lookup(&result.c_ptr_, c_ptr_, name.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_worktree_lookup(&result.c_ptr_, c_ptr_, name.c_str()));
   return result;
 }
 
 worktree repository::open_worktree() const {
   worktree result(nullptr, ownership::user);
-  if (git_worktree_open_from_repository(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+      git_worktree_open_from_repository(&result.c_ptr_, c_ptr_));
   return result;
 }
 

--- a/src/revwalk.cpp
+++ b/src/revwalk.cpp
@@ -41,30 +41,30 @@ void revwalk::add_hide_callback(std::function<int(const oid &)> callback) {
     return wrapper->fn(oid(commit_id));
   };
 
-  if (git_revwalk_add_hide_cb(c_ptr_, callback_c, (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_add_hide_cb(c_ptr_, callback_c, (void *)(&wrapper)));
 }
 
 bool revwalk::done() const { return done_; }
 
 void revwalk::hide(const oid &commit_id) {
-  if (git_revwalk_hide(c_ptr_, commit_id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_hide(c_ptr_, commit_id.c_ptr()));
 }
 
 void revwalk::hide_glob(const std::string &glob) {
-  if (git_revwalk_hide_glob(c_ptr_, glob.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_hide_glob(c_ptr_, glob.c_str()));
 }
 
 void revwalk::hide_head() {
-  if (git_revwalk_hide_head(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_hide_head(c_ptr_));
 }
 
 void revwalk::hide_reference(const std::string &ref) {
-  if (git_revwalk_hide_ref(c_ptr_, ref.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_hide_ref(c_ptr_, ref.c_str()));
 }
 
 oid revwalk::next() {
@@ -75,28 +75,28 @@ oid revwalk::next() {
 }
 
 void revwalk::push(const oid &id) {
-  if (git_revwalk_push(c_ptr_, id.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_push(c_ptr_, id.c_ptr()));
 }
 
 void revwalk::push_glob(const std::string &glob) {
-  if (git_revwalk_push_glob(c_ptr_, glob.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_push_glob(c_ptr_, glob.c_str()));
 }
 
 void revwalk::push_head() {
-  if (git_revwalk_push_head(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_push_head(c_ptr_));
 }
 
 void revwalk::push_range(const std::string &range) {
-  if (git_revwalk_push_range(c_ptr_, range.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_push_range(c_ptr_, range.c_str()));
 }
 
 void revwalk::push_reference(const std::string &ref) {
-  if (git_revwalk_push_ref(c_ptr_, ref.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_push_ref(c_ptr_, ref.c_str()));
 }
 
 cppgit2::repository revwalk::repository() {
@@ -105,18 +105,18 @@ cppgit2::repository revwalk::repository() {
 
 void revwalk::reset() {
   done_ = false;
-  if (git_revwalk_reset(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_reset(c_ptr_));
 }
 
 void revwalk::set_sorting_mode(revwalk::sort sorting_mode) {
-  if (git_revwalk_sorting(c_ptr_, static_cast<unsigned int>(sorting_mode)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_sorting(c_ptr_, static_cast<unsigned int>(sorting_mode)));
 }
 
 void revwalk::simplify_first_parent() {
-  if (git_revwalk_simplify_first_parent(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_revwalk_simplify_first_parent(c_ptr_));
 }
 
 const git_revwalk *revwalk::c_ptr() const { return c_ptr_; }

--- a/src/signature.cpp
+++ b/src/signature.cpp
@@ -11,25 +11,25 @@ signature::signature() {
 }
 
 signature::signature(const std::string &name, const std::string &email) {
-  if (git_signature_now(&c_ptr_, name.c_str(), email.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_signature_now(&c_ptr_, name.c_str(), email.c_str()));
 }
 
 signature::signature(const std::string &name, const std::string &email,
                      epoch_time_seconds time, int offset_minutes) {
-  if (git_signature_new(&c_ptr_, name.c_str(), email.c_str(), time,
-                        offset_minutes))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_signature_new(&c_ptr_, name.c_str(), email.c_str(), time,
+                      offset_minutes));
 }
 
 signature::signature(const std::string &buffer) {
-  if (git_signature_from_buffer(&c_ptr_, buffer.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_signature_from_buffer(&c_ptr_, buffer.c_str()));
 }
 
 signature::signature(const git_signature *c_ptr) {
-  if (git_signature_dup(&c_ptr_, c_ptr))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_signature_dup(&c_ptr_, c_ptr));
 }
 
 signature signature::copy() const {
@@ -37,36 +37,44 @@ signature signature::copy() const {
 }
 
 signature::signature(signature const& other) {
-  if (git_signature_dup(&c_ptr_, other.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_signature_dup(&c_ptr_, other.c_ptr_));
 }
 
 std::string signature::name() const {
   if (c_ptr_)
     return c_ptr_->name ? c_ptr_->name : "";
   else
-    throw git_exception("signature is null");
+    throw git_exception("signature is null",
+                        git_exception::error_class::invalid,
+                        git_exception::error_code::invalid);
 }
 
 std::string signature::email() const {
   if (c_ptr_)
     return c_ptr_->email ? c_ptr_->email : "";
   else
-    throw git_exception("signature is null");
+    throw git_exception("signature is null",
+                        git_exception::error_class::invalid,
+                        git_exception::error_code::invalid);
 }
 
 epoch_time_seconds signature::time() const {
   if (c_ptr_)
     return c_ptr_->when.time;
   else
-    throw git_exception("signature is null");
+    throw git_exception("signature is null",
+                        git_exception::error_class::invalid,
+                        git_exception::error_code::invalid);
 }
 
 offset_minutes signature::offset() const {
   if (c_ptr_)
     return c_ptr_->when.offset;
   else
-    throw git_exception("signature is null");
+    throw git_exception("signature is null",
+                        git_exception::error_class::invalid,
+                        git_exception::error_code::invalid);
 }
 
 const git_signature *signature::c_ptr() const { return c_ptr_; }

--- a/src/strarray.cpp
+++ b/src/strarray.cpp
@@ -59,8 +59,8 @@ strarray strarray::copy() const {
 }
 
 strarray::strarray(strarray const& other) {
-  if (git_strarray_copy(&c_struct_, &other.c_struct_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_strarray_copy(&c_struct_, &other.c_struct_));
 }
 
 std::vector<std::string> strarray::to_vector() const {

--- a/src/submodule.cpp
+++ b/src/submodule.cpp
@@ -26,18 +26,18 @@ submodule& submodule::operator=(submodule&& other) {
 }
 
 void submodule::init(bool overwrite) {
-  if (git_submodule_init(c_ptr_, overwrite))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_submodule_init(c_ptr_, overwrite));
 }
 
 void submodule::resolve_setup() {
-  if (git_submodule_add_finalize(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_submodule_add_finalize(c_ptr_));
 }
 
 void submodule::add_to_index(bool write_index) {
-  if (git_submodule_add_to_index(c_ptr_, write_index))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_submodule_add_to_index(c_ptr_, write_index));
 }
 
 std::string submodule::branch_name() const {
@@ -61,8 +61,8 @@ submodule::ignore submodule::ignore_option() const {
 
 repository submodule::initialize_repository(bool use_gitlink) {
   repository result;
-  if (git_submodule_repo_init(&result.c_ptr_, c_ptr_, use_gitlink))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_submodule_repo_init(&result.c_ptr_, c_ptr_, use_gitlink));
   return result;
 }
 
@@ -90,14 +90,14 @@ std::string submodule::path() const {
 }
 
 void submodule::reload(bool force) {
-  if (git_submodule_reload(c_ptr_, force))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_submodule_reload(c_ptr_, force));
 }
 
 cppgit2::repository submodule::open_repository() {
   cppgit2::repository result;
-  if (git_submodule_open(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_submodule_open(&result.c_ptr_, c_ptr_));
   return result;
 }
 
@@ -106,8 +106,8 @@ cppgit2::repository submodule::owner() {
 }
 
 void submodule::sync() {
-  if (git_submodule_sync(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_submodule_sync(c_ptr_));
 }
 
 std::string submodule::url() const {
@@ -120,21 +120,21 @@ std::string submodule::url() const {
 
 submodule::status submodule::location_status() const {
   unsigned int result;
-  if (git_submodule_location(&result, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_submodule_location(&result, c_ptr_));
   return static_cast<submodule::status>(result);
 }
 
 repository submodule::clone(const update_options &options) {
   repository result;
-  if (git_submodule_clone(&result.c_ptr_, c_ptr_, options.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_submodule_clone(&result.c_ptr_, c_ptr_, options.c_ptr_));
   return result;
 }
 
 void submodule::update(bool init, const update_options &options) {
-  if (git_submodule_update(c_ptr_, init, options.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_submodule_update(c_ptr_, init, options.c_ptr_));
 }
 
 const git_submodule *submodule::c_ptr() const { return c_ptr_; }

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -28,8 +28,8 @@ tag tag::copy() const {
 }
 
 tag::tag(tag const& other) : owner_(ownership::user){  
-  if (git_tag_dup(&c_ptr_, other.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_tag_dup(&c_ptr_, other.c_ptr_));
 }
 
 oid tag::id() const { return oid(git_tag_id(c_ptr_)); }
@@ -52,8 +52,8 @@ std::string tag::name() const {
 
 object tag::peel() const {
   object result(nullptr, ownership::user);
-  if (git_tag_peel(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_tag_peel(&result.c_ptr_, c_ptr_));
   return result;
 }
 
@@ -61,8 +61,8 @@ signature tag::tagger() const { return signature(git_tag_tagger(c_ptr_)); }
 
 object tag::target() const {
   object result(nullptr, ownership::user);
-  if (git_tag_target(&result.c_ptr_, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_tag_target(&result.c_ptr_, c_ptr_));
   return result;
 }
 

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -26,41 +26,41 @@ transaction& transaction::operator=(transaction&& other) {
 }
 
 void transaction::commit() {
-  if (git_transaction_commit(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_transaction_commit(c_ptr_));
 }
 
 void transaction::lock_reference(const std::string &refname) {
-  if (git_transaction_lock_ref(c_ptr_, refname.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_transaction_lock_ref(c_ptr_, refname.c_str()));
 }
 
 void transaction::remove_reference(const std::string &refname) {
-  if (git_transaction_remove(c_ptr_, refname.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_transaction_remove(c_ptr_, refname.c_str()));
 }
 
 void transaction::set_reflog(const std::string &refname, const reflog &reflog) {
-  if (git_transaction_set_reflog(c_ptr_, refname.c_str(), reflog.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_transaction_set_reflog(c_ptr_, refname.c_str(), reflog.c_ptr()));
 }
 
 void transaction::set_symbolic_target(const std::string &refname,
                                       const std::string &target,
                                       const signature &signature,
                                       const std::string &message) {
-  if (git_transaction_set_symbolic_target(c_ptr_, refname.c_str(),
-                                          target.c_str(), signature.c_ptr(),
-                                          message.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_transaction_set_symbolic_target(c_ptr_, refname.c_str(),
+                                        target.c_str(), signature.c_ptr(),
+                                        message.c_str()));
 }
 
 void transaction::set_target(const std::string &refname, const oid &target,
                              const signature &signature,
                              const std::string &message) {
-  if (git_transaction_set_target(c_ptr_, refname.c_str(), target.c_ptr(),
-                                 signature.c_ptr(), message.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_transaction_set_target(c_ptr_, refname.c_str(), target.c_ptr(),
+                               signature.c_ptr(), message.c_str()));
 }
 
 git_transaction *transaction::c_ptr() { return c_ptr_; }

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -43,8 +43,8 @@ tree::entry tree::lookup_entry_by_name(const std::string &filename) const {
 tree::entry tree::lookup_entry_by_path(const std::string &path) const {
   tree::entry result(nullptr, ownership::user);
   result.owner_ = ownership::user;
-  if (git_tree_entry_bypath(&result.c_ptr_, c_ptr_, path.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_tree_entry_bypath(&result.c_ptr_, c_ptr_, path.c_str()));
   return result;
 }
 
@@ -55,8 +55,8 @@ tree tree::copy() const {
 }
 
 tree::tree(tree const& other) : owner_(ownership::user){
-  if (git_tree_dup(&c_ptr_, other.c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_tree_dup(&c_ptr_, other.c_ptr_));
 }
 
 size_t tree::size() const { return git_tree_entrycount(c_ptr_); }
@@ -79,9 +79,9 @@ void tree::walk(traversal_mode mode,
     return wrapper->fn(root ? std::string(root) : "", tree::entry(entry));
   };
 
-  if (git_tree_walk(c_ptr_, static_cast<git_treewalk_mode>(mode), callback_c,
-                    (void *)(&wrapper)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_tree_walk(c_ptr_, static_cast<git_treewalk_mode>(mode), callback_c,
+                  (void *)(&wrapper)));
 }
 
 git_tree *tree::c_ptr() { return c_ptr_; }

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -4,8 +4,8 @@
 namespace cppgit2 {
 
 tree_builder::tree_builder(repository &repo, tree source) {
-  if (git_treebuilder_new(&c_ptr_, repo.c_ptr_, source.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_treebuilder_new(&c_ptr_, repo.c_ptr_, source.c_ptr()));
 }
 
 tree_builder::~tree_builder() {
@@ -56,27 +56,27 @@ tree::entry tree_builder::operator[](const std::string &filename) const {
 void tree_builder::insert(const std::string &filename, const oid &id,
                           file_mode mode) {
   const git_tree_entry *result = nullptr;
-  if (git_treebuilder_insert(&result, c_ptr_, filename.c_str(), id.c_ptr(),
-                             static_cast<git_filemode_t>(mode)))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_treebuilder_insert(&result, c_ptr_, filename.c_str(), id.c_ptr(),
+                           static_cast<git_filemode_t>(mode)));
 }
 
 void tree_builder::remove(const std::string &filename) {
-  if (git_treebuilder_remove(c_ptr_, filename.c_str()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_treebuilder_remove(c_ptr_, filename.c_str()));
 }
 
 oid tree_builder::write() {
   git_oid id;
-  if (git_treebuilder_write(&id, c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_treebuilder_write(&id, c_ptr_));
   return oid(&id);
 }
 
 oid tree_builder::write(data_buffer &tree) {
   git_oid id;
-  if (git_treebuilder_write_with_buffer(&id, c_ptr_, tree.c_ptr()))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_treebuilder_write_with_buffer(&id, c_ptr_, tree.c_ptr()));
   return oid(&id);
 }
 

--- a/src/worktree.cpp
+++ b/src/worktree.cpp
@@ -38,7 +38,7 @@ std::pair<bool, std::string> worktree::is_locked() const {
     // Not locked
     return std::pair<bool, std::string>{false, ""};
   } else {
-    throw git_exception();
+    throw git_exception(ret);
   }
 }
 
@@ -46,37 +46,25 @@ bool worktree::is_prunable(unsigned int version, uint32_t flags) const {
   git_worktree_prune_options options;
   options.version = version;
   options.flags = flags;
-  auto ret = git_worktree_is_prunable(c_ptr_, &options);
-  if (ret == 1)
-    return true;
-  else if (ret == 0)
-    return false;
-  else
-    throw git_exception();
+  return git_exception::throw_nonbool(
+    git_worktree_is_prunable(c_ptr_, &options));
 }
 
 bool worktree::is_prunable() const {
   git_worktree_prune_options options;
   // Initializes a git_worktree_prune_options with default values. Equivalent to
   // creating an instance with GIT_WORKTREE_PRUNE_OPTIONS_INIT.
-  auto ret = git_worktree_prune_options_init(
-      &options, GIT_WORKTREE_PRUNE_OPTIONS_VERSION);
-  if (ret == 0) {
-    ret = git_worktree_is_prunable(c_ptr_, &options);
-    if (ret == 1)
-      return true;
-    else if (ret == 0)
-      return false;
-    else
-      throw git_exception();
-  } else
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_worktree_prune_options_init(
+        &options, GIT_WORKTREE_PRUNE_OPTIONS_VERSION));
+  return git_exception::throw_nonbool(
+    git_worktree_is_prunable(c_ptr_, &options));
 }
 
 void worktree::lock(const std::string &reason) {
   const char *reason_c = reason.empty() ? nullptr : reason.c_str();
-  if (git_worktree_lock(c_ptr_, reason_c))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_worktree_lock(c_ptr_, reason_c));
 }
 
 std::string worktree::name() const {
@@ -99,26 +87,24 @@ void worktree::prune(unsigned int version, uint32_t flags) {
   git_worktree_prune_options options;
   options.version = version;
   options.flags = flags;
-  if (git_worktree_prune(c_ptr_, &options))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_worktree_prune(c_ptr_, &options));
 }
 
 void worktree::prune() {
   git_worktree_prune_options options;
   // Initializes a git_worktree_prune_options with default values. Equivalent to
   // creating an instance with GIT_WORKTREE_PRUNE_OPTIONS_INIT.
-  auto ret = git_worktree_prune_options_init(
-      &options, GIT_WORKTREE_PRUNE_OPTIONS_VERSION);
-  if (ret == 0) {
-    if (git_worktree_prune(c_ptr_, &options))
-      throw git_exception();
-  } else
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_worktree_prune_options_init(
+        &options, GIT_WORKTREE_PRUNE_OPTIONS_VERSION));
+  git_exception::throw_nonzero(
+    git_worktree_prune(c_ptr_, &options));
 }
 
 void worktree::unlock() {
-  if (git_worktree_unlock(c_ptr_))
-    throw git_exception();
+  git_exception::throw_nonzero(
+    git_worktree_unlock(c_ptr_));
 }
 
 bool worktree::is_valid() { return git_worktree_validate(c_ptr_) == 0; }


### PR DESCRIPTION
this involved mutating the entire codebase so as to pass the return code in

i was a little surprised there wasn't an existing macro to change for this. i made a couple static helper functions to inline instead.